### PR TITLE
Created options and TJParseException to start throwing exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ static const short TJ_VERSION_PATCH = 1;
 static const char TJ_VERSION_STRING[] = "0.0.1";
 ```
 
+### Exceptions
+
+#### Parsing Exception
+
+The parsing exception is `TinyJSON::TJParseException` and can be made optional in the `TinyJSON::options` flag.
+
+```cpp
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  try
+  {
+    auto blah = TinyJSON::TinyJSON::parse("[0123]", options)
+    ...
+  }
+  catch(TinyJSON::TJParseException ex)
+  {
+     ex.what(); // Numbers cannot have leading zeros
+  }
+```
+
 ### Read a JSON file
 
 To read a JSON file you simply need to call the static method `parse_file`, the extention does not have to be `.json`

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -130,6 +130,120 @@ namespace TinyJSON
   };
 
   ///////////////////////////////////////
+  // Parse result.
+  class ParseResult
+  {
+  public:
+    ParseResult(const options& options) :
+      _parse_exception_message(nullptr),
+      _options(options)
+    {
+    }
+
+    ParseResult(const ParseResult& parse_result) = delete;
+    ParseResult& operator=(const ParseResult& parse_result) = delete;
+
+    ~ParseResult()
+    {
+      free_parse_exception_message();
+    }
+
+    /// <summary>
+    /// Assign a parse error message.
+    /// </summary>
+    /// <param name="parse_exception_message"></param>
+    void assign_parse_exception_message(const char* parse_exception_message)
+    {
+      free_parse_exception_message();
+      if (parse_exception_message != nullptr)
+      {
+        auto length = strlen(parse_exception_message);
+        _parse_exception_message = new char[length + 1];
+        std::strcpy(_parse_exception_message, parse_exception_message);
+      }
+    }
+
+    void throw_if_parse_exception()
+    {
+      if (!_options.throw_exception)
+      {
+        return;
+      }
+      if (nullptr == _parse_exception_message)
+      {
+        return;
+      }
+      throw TJParseException(_parse_exception_message);
+    }
+
+  protected:
+    void free_parse_exception_message() noexcept
+    {
+      if (_parse_exception_message != nullptr)
+      {
+        delete[] _parse_exception_message;
+        _parse_exception_message = nullptr;
+      }
+    }
+
+    char* _parse_exception_message;
+    const options& _options;
+  };
+
+  ///////////////////////////////////////
+  /// Parsing Exception
+  TJParseException::TJParseException(const char* message) :
+    _message(nullptr)
+  {
+    assign_message(message);
+  }
+
+  TJParseException::TJParseException(const TJParseException& exception)
+    : _message(nullptr)
+  {
+    *this = exception;
+  }
+
+  TJParseException::~TJParseException()
+  {
+    free_message();
+  }
+
+  TJParseException& TJParseException::operator=(const TJParseException& exception)
+  {
+    if (this != &exception)
+    {
+      assign_message(exception._message);
+    }
+    return *this;
+  }
+
+  const char* TJParseException::what() const noexcept
+  {
+    return _message == nullptr ? "Unknown" : _message;
+  }
+
+  void TJParseException::assign_message(const char* message)
+  {
+    free_message();
+    if (message != nullptr)
+    {
+      auto length = strlen(message);
+      _message = new char[length + 1];
+      std::strcpy(_message, message);
+    }
+  }
+
+  void TJParseException::free_message() noexcept
+  {
+    if (_message != nullptr)
+    {
+      delete[] _message;
+      _message = nullptr;
+    }
+  }
+
+  ///////////////////////////////////////
   /// Protected Helper class
   class TJHelper
   {
@@ -659,7 +773,7 @@ namespace TinyJSON
       return new_string;
     }
 
-    static void add_char_to_string(const TJCHAR char_to_add, TJCHAR*& buffer, int& buffer_pos, int& buffer_max_length)
+    static void add_char_to_string(const TJCHAR char_to_add, TJCHAR*& buffer, int& buffer_pos, int& buffer_max_length) noexcept
     {
       if (buffer_pos + 1 >= buffer_max_length)
       {
@@ -671,7 +785,7 @@ namespace TinyJSON
       ++buffer_pos;
     }
 
-    static void add_string_to_string(const TJCHAR* string_to_add, TJCHAR*& buffer, int& buffer_pos, int& buffer_max_length)
+    static void add_string_to_string(const TJCHAR* string_to_add, TJCHAR*& buffer, int& buffer_pos, int& buffer_max_length) noexcept
     {
       if (nullptr == string_to_add)
       {
@@ -794,7 +908,7 @@ namespace TinyJSON
       return false;
     }
 
-    static TJCHAR* try_continue_read_string(const TJCHAR*& p)
+    static TJCHAR* try_continue_read_string(const TJCHAR*& p, ParseResult& parse_result)
     {
       int result_pos = 0;
       int result_max_length = 0;
@@ -810,8 +924,9 @@ namespace TinyJSON
           case TJ_ESCAPE_LINE_FEED:       // % x6E / ; n    line feed       U + 000A
           case TJ_ESCAPE_CARRIAGE_RETURN: // % x72 / ; r    carriage return U + 000D
           case  TJ_ESCAPE_TAB:            // % x74 / ; t    tab             U + 0009
-            delete[] result;
             // ERROR: invalid character inside the string.
+            delete[] result;
+            parse_result.assign_parse_exception_message("Invalid character inside the string.");
             return nullptr;
           }
           add_char_to_string(*p, result, result_pos, result_max_length);
@@ -822,7 +937,8 @@ namespace TinyJSON
           if (!try_add_char_to_string_after_escape(p, result, result_pos, result_max_length))
           {
             delete[] result;
-            // ERROR: single reverse solidus
+            // ERROR: invalid/unknown character after single reverse solidus.
+            parse_result.assign_parse_exception_message("Invalid/unknown character after single reverse solidus.");
             return nullptr;
           }
           p++;
@@ -839,6 +955,7 @@ namespace TinyJSON
         case TJ_ESCAPE_FORM_FEED:       // % x66 / ; f    form feed       U + 000C
           delete[] result;
           // ERROR: invalid character inside the string.
+          parse_result.assign_parse_exception_message("Invalid character inside the string..");
           return nullptr;
 
         TJ_CASE_START_STRING
@@ -859,6 +976,7 @@ namespace TinyJSON
 
       // // ERROR: we could not close the object.
       delete[] result;
+      parse_result.assign_parse_exception_message("We could not close the string.");
       return nullptr;
     }
 
@@ -1006,7 +1124,7 @@ namespace TinyJSON
       // so we are not shifting the whole way but we have to be careful as the
       // len of the fraction might actually be less than the fraction because of leading 0s
       // for example 0.0012 and 0.12 have a len of 2 but a fraction_exponent of 2 and 4
-      // the lenght can never be more than the fraction exponent.
+      // the length can never be more than the fraction exponent.
       const auto& fraction_length = get_number_of_digits(fraction);
 
       if (fraction_length == fraction_exponent)
@@ -1575,7 +1693,7 @@ namespace TinyJSON
     /// </summary>
     /// <param name="p"></param>
     /// <returns></returns>
-    static TJValue* try_continue_read_object(const TJCHAR*& p)
+    static TJValue* try_continue_read_object(const TJCHAR*& p, ParseResult& parse_result)
     {
       //  assume no members in that object.
       bool found_comma = false;
@@ -1587,29 +1705,30 @@ namespace TinyJSON
         TJCHAR c = *p;
         switch (c)
         {
-          TJ_CASE_SPACE
-            p++;
+        TJ_CASE_SPACE
+          p++;
           break;
 
-          TJ_CASE_END_OBJECT
-            // but is it what we expected?
-            if (waiting_for_a_string)
-            {
-              // ERROR: unexpected end of object, there was a "," after
-              //        the last string and we expected a string now, not a close "}"
-              free_members(members);
-              return nullptr;
-            }
+        TJ_CASE_END_OBJECT
+          // but is it what we expected?
+          if (waiting_for_a_string)
+          {
+            // ERROR: unexpected end of object, there was a "," after
+            //        the last string and we expected a string now, not a close "}"
+            free_members(members);
+            parse_result.assign_parse_exception_message("Unexpected end of object, there was a ', ' after the last string.");
+            return nullptr;
+          }
           p++;
 
           // we are done, we found it.
           // we give the ownership of the members over.
           return TJValueObject::move(members);
 
-          TJ_CASE_START_STRING
-          {
-            // we got our string, no longer waiting for one.
-            waiting_for_a_string = false;
+        TJ_CASE_START_STRING
+        {
+          // we got our string, no longer waiting for one.
+          waiting_for_a_string = false;
 
           // we are no longer after the string
           after_string = false;
@@ -1621,12 +1740,13 @@ namespace TinyJSON
           {
             // ERROR: expected a comma after the last element
             free_members(members);
+            parse_result.assign_parse_exception_message("Expected a comma after the last element.");
             return nullptr;
           }
 
           // read the actual string and value
           // that's the way it has to be.
-          auto member = try_read_string_and_value(p);
+          auto member = try_read_string_and_value(p, parse_result);
           if (member == nullptr)
           {
             // ERROR: There was an error reading the name and/or the value
@@ -1638,16 +1758,17 @@ namespace TinyJSON
           move_member_to_members(member, members);
           
           after_string = true;
-          }
-          break;
+        }
+        break;
 
-          TJ_CASE_COMMA
-            if (!after_string)
-            {
-              // ERROR: found a comma out of order
-              free_members(members);
-              return nullptr;
-            }
+        TJ_CASE_COMMA
+          if (!after_string)
+          {
+            // ERROR: found a comma out of order
+            free_members(members);
+            parse_result.assign_parse_exception_message("Found a comma out of order.");
+            return nullptr;
+          }
           // we are no longer after the string
           after_string = false;
           waiting_for_a_string = true;
@@ -1658,12 +1779,14 @@ namespace TinyJSON
         default:
           // ERROR: unknown character
           free_members(members);
+          parse_result.assign_parse_exception_message("Unknown character.");
           return nullptr;
         }
       }
 
       // ERROR end of the string was found and we didn't find what we needed.
       free_members(members);
+      parse_result.assign_parse_exception_message("End of the string was found and we didn't find what we needed.");
       return nullptr;
     }
 
@@ -1673,7 +1796,7 @@ namespace TinyJSON
     /// </summary>
     /// <param name="p"></param>
     /// <returns></returns>
-    static TJValue* try_continue_read_array(const TJCHAR*& p)
+    static TJValue* try_continue_read_array(const TJCHAR*& p, ParseResult& parse_result)
     {
       //  assume no values in that array
       std::vector<TJValue*>* values = nullptr;
@@ -1684,31 +1807,33 @@ namespace TinyJSON
         TJCHAR c = *p;
         switch (c)
         {
-          TJ_CASE_SPACE
-            p++;
+        TJ_CASE_SPACE
+          p++;
           break;
 
-          TJ_CASE_END_ARRAY
-            if (found_comma && waiting_for_a_value)
-            {
-              // ERROR: unexpected end of array, there was a "," after
-              //        the last value and we expected a value now, not a close "]"
-              free_values(values);
-              return nullptr;
-            }
+        TJ_CASE_END_ARRAY
+          if (found_comma && waiting_for_a_value)
+          {
+            // ERROR: unexpected end of array, there was a "," after
+            //        the last value and we expected a value now, not a close "]"
+            free_values(values);
+            parse_result.assign_parse_exception_message("Unexpected end of array, there was a ', ' after the last string.");
+            return nullptr;
+          }
           p++;
 
           // we are done, we found it.
           // we give the ownership of the members over.
           return TJValueArray::move(values);
 
-          TJ_CASE_COMMA
-            if (waiting_for_a_value)
-            {
-              // ERROR: found a comma out of order, (2 commas)
-              free_values(values);
-              return nullptr;
-            }
+        TJ_CASE_COMMA
+          if (waiting_for_a_value)
+          {
+            // ERROR: found a comma out of order, (2 commas)
+            free_values(values);
+            parse_result.assign_parse_exception_message("Found a comma out of order, (2 commas).");
+            return nullptr;
+          }
           // we are now waiting for a value
           waiting_for_a_value = true;
           found_comma = true;
@@ -1716,7 +1841,7 @@ namespace TinyJSON
           break;
 
         default:
-          const auto& value = try_read_Value(p);
+          const auto& value = try_read_Value(p, parse_result);
           if (value == nullptr)
           {
             // ERROR: unknown character
@@ -1732,6 +1857,7 @@ namespace TinyJSON
             // ERROR: We found a value but we expected a comma.
             delete value;
             free_values(values);
+            parse_result.assign_parse_exception_message("We found a value but we expected a comma.");
             return nullptr;
           }
           values->push_back(value);
@@ -1741,12 +1867,13 @@ namespace TinyJSON
         }
       }
 
-      // ERROR end of the string was found and we didn't find what we needed.
+      // ERROR: end of the string was found and we didn't find what we needed.
       free_values(values);
+      parse_result.assign_parse_exception_message("End of the string was found and we didn't find what we needed.");
       return nullptr;
     }
 
-    static TJValue* try_read_Value(const TJCHAR*& p)
+    static TJValue* try_read_Value(const TJCHAR*& p, ParseResult& parse_result)
     {
       while (*p != TJ_NULL_TERMINATOR)
       {
@@ -1759,10 +1886,10 @@ namespace TinyJSON
 
         TJ_CASE_START_STRING
         {
-          auto string_value = try_continue_read_string(++p);
+          auto string_value = try_continue_read_string(++p, parse_result);
           if (nullptr == string_value)
           {
-            //  ERROR could not read the string properly.
+            //  ERROR: could not read the string properly.
             return nullptr;
           }
 
@@ -1777,6 +1904,7 @@ namespace TinyJSON
             if (nullptr == true_value)
             {
               //  ERROR could not read the word 'true'
+              parse_result.assign_parse_exception_message("Could not read the word 'true'.");
               return nullptr;
             }
             return true_value;
@@ -1787,7 +1915,8 @@ namespace TinyJSON
           auto false_value = try_continue_read_false(++p);
           if (nullptr == false_value)
           {
-            //  ERROR could not read the word 'true'
+            //  ERROR: could not read the word 'false'
+            parse_result.assign_parse_exception_message("Could not read the word 'false'.");
             return nullptr;
           }
           return false_value;
@@ -1798,7 +1927,8 @@ namespace TinyJSON
           auto null_value = try_continue_read_null(++p);
           if (nullptr == null_value)
           {
-            //  ERROR could not read the word 'true'
+            //  ERROR: could not read the word 'null'
+            parse_result.assign_parse_exception_message("Could not read the word 'null'.");
             return nullptr;
           }
           return null_value;
@@ -1810,7 +1940,8 @@ namespace TinyJSON
           auto number = try_read_number(p);
           if (nullptr == number)
           {
-            //  ERROR could not read the word 'true'
+            //  ERROR: could not read number
+            parse_result.assign_parse_exception_message("Could not read number.");
             return nullptr;
           }
           return number;
@@ -1819,10 +1950,10 @@ namespace TinyJSON
         TJ_CASE_BEGIN_ARRAY
         {
           // an array within an array
-          auto tjvalue_array = try_continue_read_array(++p);
+          auto tjvalue_array = try_continue_read_array(++p, parse_result);
           if (tjvalue_array == nullptr)
           {
-            // Error:  something went wrong, the error was logged.
+            // Error: something went wrong reading an array, the error was logged.
             return nullptr;
           }
           return tjvalue_array;
@@ -1831,10 +1962,10 @@ namespace TinyJSON
         TJ_CASE_BEGIN_OBJECT
         {
           // an object within the object
-          auto tjvalue_object = try_continue_read_object(++p);
+          auto tjvalue_object = try_continue_read_object(++p, parse_result);
           if (tjvalue_object == nullptr)
           {
-            // Error:  something went wrong, the error was logged.
+            // Error: something went wrong reading an object, the error was logged.
             return nullptr;
           }
           return tjvalue_object;
@@ -1850,13 +1981,13 @@ namespace TinyJSON
       return nullptr;
     }
 
-    static TJMember* try_read_string_and_value(const TJCHAR*& p)
+    static TJMember* try_read_string_and_value(const TJCHAR*& p, ParseResult& parse_result)
     {
       // first we look for the string, all the elements are supposed to have one.
-      auto string_value = try_continue_read_string(++p);
+      auto string_value = try_continue_read_string(++p, parse_result);
       if (string_value == nullptr)
       {
-        //  ERROR: could not read the string.
+        //  ERROR: could not read the string
         return nullptr;
       }
 
@@ -1865,11 +1996,12 @@ namespace TinyJSON
       if (!try_skip_colon(p))
       {
         delete[] string_value;
-        //  ERROR: Could not locate the expected colon
+        //  ERROR: could not locate the expected colon after the key value
+        parse_result.assign_parse_exception_message("Could not locate the expected colon after the key value.");
         return nullptr;
       }
 
-      auto value = try_read_Value(p);
+      auto value = try_read_Value(p, parse_result);
       if (nullptr == value)
       {
         delete[] string_value;
@@ -1918,8 +2050,9 @@ namespace TinyJSON
   /// Parse a json file
   /// </summary>
   /// <param name="source">The source file we are trying to parse.</param>
+  /// <param name="options">The option we want to use when parsing this.</param>
   /// <returns></returns>
-  TJValue* TinyJSON::parse_file(const TJCHAR* file_path)
+  TJValue* TinyJSON::parse_file(const TJCHAR* file_path, const options& options)
   {
     // sanity check
     if (nullptr == file_path)
@@ -1948,34 +2081,64 @@ namespace TinyJSON
     // we can explicitely close the file to free the resources.
     file.close();
 
-    // parse the file.
-    auto value = parse(buffer);
-    
-    // get rid of the buffer
-    delete[] buffer;
+    try
+    {
+      // parse the file.
+      auto value = internal_parse(buffer, options);
 
-    // return whatever we managed to read out of the file.
-    return value;
+      // get rid of the buffer
+      delete[] buffer;
+
+      // return whatever we managed to read out of the file.
+      return value;
+    }
+    catch (...)
+    {
+      // get rid of the buffer
+      delete[] buffer;
+
+      // rethrow.
+      throw;
+    }
   }
 
   /// <summary>
   /// Parse a json string
   /// </summary>
   /// <param name="source">The source we are trying to parse.</param>
+  /// <param name="options">The option we want to use when parsing this.</param>
   /// <returns></returns>
-  TJValue* TinyJSON::parse(const TJCHAR* source)
+  TJValue* TinyJSON::parse(const TJCHAR* source, const options& options)
   {
+    return internal_parse(source, options);
+  }
+
+  /// <summary>
+  /// Internal parsing of a json source
+  /// We will use the option to throw, (or not).
+  /// </summary>
+  /// <param name="source"></param>
+  /// <param name="options"></param>
+  /// <returns></returns>
+  TJValue* TinyJSON::internal_parse(const TJCHAR* source, const options& options)
+  {
+    // sanity check
+    if (nullptr == source)
+    {
+      if (options.throw_exception)
+      {
+        throw TJParseException("The given source is null.");
+      }
+      return nullptr;
+    }
+
     // if we have a utf-8 content then we just skip those.
     if (TJHelper::has_utf8_bom(source))
     {
       source += 3;
     }
 
-    // sanity check
-    if (nullptr == source)
-    {
-      return nullptr;
-    }
+    ParseResult parse_result(options);
 
     // we can only have one value and nothing else
     TJValue* value_found = nullptr;
@@ -1997,10 +2160,11 @@ namespace TinyJSON
         }
 
         // try and look for the value
-        value_found = TJHelper::try_read_Value(source);
+        value_found = TJHelper::try_read_Value(source, parse_result);
         if (nullptr == value_found)
         {
           // there was an issue trying to parse.
+          parse_result.throw_if_parse_exception();
           return nullptr;
         }
         break;
@@ -2010,6 +2174,7 @@ namespace TinyJSON
     // return if we found anything.
     // if we found nothing ... then it is not an error, 
     // just an empty string
+    parse_result.throw_if_parse_exception();
     return value_found != nullptr ? value_found : new TJValueString(TJCHARPREFIX(""));
   }
 

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -42,6 +42,38 @@ namespace TinyJSON
     indented
   };
 
+  /// <summary>
+  /// The parsing options.
+  /// </summary>
+  struct options
+  {
+    /// <summary>
+    /// If we want to throw an exception or not.
+    /// </summary>
+    bool throw_exception = false;
+
+    /// <summary>
+    /// How deep we want to allow the array/objects to recurse.
+    /// </summary>
+    unsigned int max_depth = 64;  
+  };
+
+  class TJParseException : public std::exception
+  {
+  public:
+    TJParseException(const char* message);
+    TJParseException(const TJParseException& exception);
+    TJParseException& operator=(const TJParseException& exception);
+    virtual ~TJParseException() noexcept;
+
+    virtual const char* what() const noexcept;
+
+  private:
+    void free_message() noexcept;
+    void assign_message(const char* message);
+    char* _message;
+  };
+
   struct internal_dump_configuration;
   class TJHelper;
   class TJValueArray;
@@ -96,15 +128,27 @@ namespace TinyJSON
     /// Parse a json string
     /// </summary>
     /// <param name="source">The source we are trying to parse.</param>
+    /// <param name="options">The option we want to use when parsing this.</param>
     /// <returns></returns>
-    static TJValue* parse(const TJCHAR* source);
+    static TJValue* parse(const TJCHAR* source, const options& options = {});
 
     /// <summary>
     /// Parse a json file
     /// </summary>
     /// <param name="file_path">The source file we are trying to parse.</param>
+    /// <param name="options">The option we want to use when parsing this.</param>
     /// <returns></returns>
-    static TJValue* parse_file(const TJCHAR* file_path);
+    static TJValue* parse_file(const TJCHAR* file_path, const options& options = {});
+
+  protected:
+    /// <summary>
+    /// Internal parsing of a json source
+    /// We will use the option to throw, (or not).
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    static TJValue* internal_parse(const TJCHAR* source, const options& options);
 
   private:
     TinyJSON() = delete;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set( Sources
   "testtinyjsonarrays.cpp"
   "testtinyjsonbooleans.cpp"
   "testtinyjsondump.cpp"
+  "testtinyjsonexceptions.cpp"
   "testtinyjsonexponents.cpp"
   "testtinyjsonnulls.cpp"
   "testtinyjsonnumbers.cpp"

--- a/tests/testjsonchecker.cpp
+++ b/tests/testjsonchecker.cpp
@@ -51,24 +51,33 @@ TEST(JSONchecker, AllFiles)
       continue;
     }
 
-    const auto& filename = file.path().string();
-    auto json = TinyJSON::TinyJSON::parse_file(filename.c_str());
+    TinyJSON::options options;
     if (is_fail)
     {
-      EXPECT_EQ(nullptr, json);
-      if (nullptr != json)
-      {
-        std::cout << "Expected Fail: " << std::filesystem::path(file.path()).filename() << '\n';
-      }
+      // we expect a failure here
+      options.throw_exception = false;
     }
     else
     {
-      EXPECT_NE(nullptr, json);
-      if (nullptr == json)
+      options.throw_exception = true;
+    }
+    
+    const auto& filename = file.path().string();
+    try
+    {
+      auto json = TinyJSON::TinyJSON::parse_file(filename.c_str(), options);
+      if (is_fail && json != nullptr)
       {
-        std::cout << "Expected Pass: " << std::filesystem::path(file.path()).filename() << '\n';
+        EXPECT_TRUE(false) << "Expected Fail: " << std::filesystem::path(file.path()).filename();
+      }
+      delete json;
+    }
+    catch(TinyJSON::TJParseException ex)
+    {
+      if (!is_fail)
+      {
+        EXPECT_TRUE(false) << "Expected Pass: " << std::filesystem::path(file.path()).filename() << "\nException: " << ex.what();
       }
     }
-    delete json;
   }
 }

--- a/tests/testtinyjsonexceptions.cpp
+++ b/tests/testtinyjsonexceptions.cpp
@@ -125,14 +125,20 @@ TEST(TestException, BadNull) {
   EXPECT_THROW(TinyJSON::TinyJSON::parse("[nul]", options), TinyJSON::TJParseException);
 }
 
+TEST(TestException, MissingColonInObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse(R"({ "Missing colon" null })", options), TinyJSON::TJParseException);
+}
+
 TEST(TestException, InvalidNumberWithLeadingZero) {
   TinyJSON::options options = {};
   options.throw_exception = true;
   EXPECT_THROW(TinyJSON::TinyJSON::parse("[0123]", options), TinyJSON::TJParseException);
 }
 
-TEST(TestException, MissingColonInObject) {
+TEST(TestException, ExponentsWithZero) {
   TinyJSON::options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse(R"({ "Missing colon" null })", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[1e00]", options), TinyJSON::TJParseException);
 }

--- a/tests/testtinyjsonexceptions.cpp
+++ b/tests/testtinyjsonexceptions.cpp
@@ -1,0 +1,138 @@
+// Licensed to Florent Guelfucci under one or more agreements.
+// Florent Guelfucci licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#include <gtest/gtest.h>
+#define TJ_USE_CHAR 1
+#include "../src/TinyJSON.h"
+
+TEST(TestException, SourceCannotBeNull) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse(nullptr, options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, EscapedTabCharacterInString) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Tab\tin string\"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, EscapedReturnCharacterInString) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Return\rin string\"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, EscapedLineFeedCharacterInString) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Line Feed\nin string\"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, EscapedFormFeedCharacterInString) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Form Feed\fin string\"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, EscapedBackSpaceCharacterInString) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"BackSpace\bin string\"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, SingleEscapeCharacterInString) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Single Escape \\ \"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, TheStringIsNotClosed) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("\"Not Closedd", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, CommaAtTheEndOfObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("{\"a\" : 12,}", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, CommaAtTheEndOfArray) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[12,]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, UnExpectedCommaInObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("{,}", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, UnExpectedCommaInArray) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[,]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, MissingCommaBetweenItemsInObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("{\"a\" : 12 \"b\" : 12}", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, MissingCommaBetweenItemsInArray) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[12 \"a\"]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, UnExpectedCharacterInObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("{ % }", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, UnExpectedEndOfStringWhileParsingObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("{", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, UnExpectedEndOfStringWhileParsingArray) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, BadTrue) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[tru]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, BadFalse) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[fals]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, BadNull) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[nul]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, InvalidNumberWithLeadingZero) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse("[0123]", options), TinyJSON::TJParseException);
+}
+
+TEST(TestException, MissingColonInObject) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  EXPECT_THROW(TinyJSON::TinyJSON::parse(R"({ "Missing colon" null })", options), TinyJSON::TJParseException);
+}

--- a/tests/testtinyjsonexceptions.cpp
+++ b/tests/testtinyjsonexceptions.cpp
@@ -5,11 +5,40 @@
 #define TJ_USE_CHAR 1
 #include "../src/TinyJSON.h"
 
-TEST(TestException, SourceCannotBeNull) {
+TEST(TestException, IfWeHaveNoExceptionWeDoNotThrow) {
   TinyJSON::options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse(nullptr, options), TinyJSON::TJParseException);
+  TinyJSON::TJValue* json = nullptr;
+  EXPECT_NO_THROW( json = TinyJSON::TinyJSON::parse("[12,13,14]", options));
+  delete json;
 }
+
+TEST(TestException, ParseExceptionMessageIsSetProperly) {
+  TinyJSON::options options = {};
+  options.throw_exception = true;
+  TinyJSON::TJValue* json = nullptr;
+  EXPECT_NO_THROW(json = TinyJSON::TinyJSON::parse("[12,13,14]", options));
+  delete json;
+}
+
+TEST(TestException, SourceCannotBeNull) {
+  TinyJSON::TJParseException ex("Hello");
+  EXPECT_STREQ("Hello", ex.what());
+}
+
+TEST(TestException, OperatorCopyParseException) {
+  TinyJSON::TJParseException ex1("Hello");
+  TinyJSON::TJParseException ex2("World");
+  ex2 = ex1;
+  EXPECT_STREQ("Hello", ex2.what());
+}
+
+TEST(TestException, CopyConstructorParseException) {
+  TinyJSON::TJParseException ex1("Hello");
+  TinyJSON::TJParseException ex2(ex1);
+  EXPECT_STREQ("Hello", ex2.what());
+}
+
 
 TEST(TestException, EscapedTabCharacterInString) {
   TinyJSON::options options = {};


### PR DESCRIPTION
Added feature to throw an exception if we want rather than return null

```cpp
  TinyJSON::options options = {};
  options.throw_exception = true;
  try
  {
    auto blah = TinyJSON::TinyJSON::parse("[0123]", options)
    ...
  }
  catch(TinyJSON::TJParseException ex)
  {
     ex.what(); // Numbers cannot have leading zeros
  }
```