### PR TITLE
Feature/user literal

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -45,6 +45,14 @@ jobs:
         set +e
         ./options
 
+    - name: user literals
+      run: g++ -std=c++20 src/TinyJSON.cpp example/user_literals.cpp -o user_literals
+
+    - name: run user literals
+      run: |
+        set +e
+        ./options
+      
   build11:
     name: Build C++ 11
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ options.max_depth = 10;
 
 try
 {
-  auto blah = TinyJSON::TinyJSON::parse("[0123]", options)
+  auto blah = TinyJSON::TJ::parse("[0123]", options)
   ...
 }
 catch(TinyJSON::TJParseException ex)
@@ -112,7 +112,7 @@ try
   ...
   // get JSON somewhere or create it.
   ...
-  if( TinyJSON::TinyJSON::write_file("file.json", *json, options))
+  if( TinyJSON::TJ::write_file("file.json", *json, options))
   {
     // all good
   }
@@ -135,7 +135,7 @@ The parsing exception is `TinyJSON::TJParseException` and can be made optional i
   options.throw_exception = true;
   try
   {
-    auto blah = TinyJSON::TinyJSON::parse("[0123]", options)
+    auto blah = TinyJSON::TJ::parse("[0123]", options)
     ...
   }
   catch(TinyJSON::TJParseException ex)
@@ -155,8 +155,8 @@ The parsing exception is `TinyJSON::TJParseException` and can be made optional i
 
   try
   {
-    auto json = TinyJSON::TinyJSON::parse( "{ \"Hello\" : \"World\" }" );
-    TinyJSON::TinyJSON::write_file("file.json", *json, options)
+    auto json = TinyJSON::TJ::parse( "{ \"Hello\" : \"World\" }" );
+    TinyJSON::TJ::write_file("file.json", *json, options)
     ...
   }
   catch(TinyJSON::TJWriteException ex)
@@ -167,10 +167,10 @@ The parsing exception is `TinyJSON::TJParseException` and can be made optional i
 
 ### Check if JSON is valid
 
-You can simply call the `TinyJSON::TinyJSON::is_valid(...)` method
+You can simply call the `TinyJSON::TJ::is_valid(...)` method
 
 ```cpp
-    if(TinyJSON::TinyJSON::parse("[123,456]"))
+    if(TinyJSON::TJ::parse("[123,456]"))
     {
       // do this
     }
@@ -185,7 +185,7 @@ You can simply call the `TinyJSON::TinyJSON::is_valid(...)` method
 To read a JSON file you simply need to call the static method `parse_file`, the extention does not have to be `.json`
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse_file( "myfile.json" );
+  auto json = TinyJSON::TJ::parse_file( "myfile.json" );
   ...
   delete json;
 ```
@@ -197,7 +197,7 @@ This will then return an object that you can inspect as per normal.
 To read a JSON string you simply need to call the static method `parse`
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse( "{ \"Hello\" : \"World\" }" );
+  auto json = TinyJSON::TJ::parse( "{ \"Hello\" : \"World\" }" );
   ...
   delete json;
 ```
@@ -211,13 +211,28 @@ This will then return an object that you can inspect.
   ...
 ```
 
+You can also use a literal
+
+```cpp
+using namespace TinyJSON;
+...
+auto json = "[12,13,14]"_tj;
+
+// use it.
+
+...
+delete json;
+...
+
+```
+
 ### Write a JSON string
 
 To write a JSON string you simply need to call the method `write_file` on the JSON object returned.
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse( "{ \"Hello\" : \"World\" }" );
-  if( TinyJSON::TinyJSON::write_file("file.json", *json))
+  auto json = TinyJSON::TJ::parse( "{ \"Hello\" : \"World\" }" );
+  if( TinyJSON::TJ::write_file("file.json", *json))
   {
     // all good
   }
@@ -238,7 +253,7 @@ Regardless if you are parsing a file or parsing a string, TinyJSON will parse th
 While you can `dump` a string to (re)write a json string you might want to use it directly in your code.
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse( R"("This is a test \" with a quote")" );
+  auto json = TinyJSON::TJ::parse( R"("This is a test \" with a quote")" );
   auto actual_string = json->dump_string(); 
   /*
     This is a test " with a quote
@@ -259,7 +274,7 @@ The formating types are
 Each objects are read into `TJValue*` classes of type `TJValueObject`.
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse( "{ \"Hello\" : \"World\" }" );
+  auto json = TinyJSON::TJ::parse( "{ \"Hello\" : \"World\" }" );
   auto value = json->try_get_string("Hello"); //  "World"
   auto no_value = json->try_get_string("Life"); //  null
 
@@ -272,7 +287,7 @@ Each arrays are read into `TJValue*` classes of type `TJValueArray`.
 Then each items in the array are also `TJValue*` of type string, number and so on.
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse( "[ 12, 14, 16 ]" );
+  auto json = TinyJSON::TJ::parse( "[ 12, 14, 16 ]" );
   auto array_of_values = dynamic_cast<TinyJSON::TJValueArray*>(json);
   auto number_of_items = array_of_values->get_number_of_items();  // 3
 
@@ -290,7 +305,7 @@ Each `TJValue*` item can be of different type
 Assuming the array below with multiple items, you can query the type of each `TJValue*` and do something accordingly.
 
 ```cpp
-  auto json = TinyJSON::TinyJSON::parse( "[ ... ]" );
+  auto json = TinyJSON::TJ::parse( "[ ... ]" );
   auto array_of_values = dynamic_cast<TinyJSON::TJValueArray*>(json);
 
   auto value = array_of_values->at(0);

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ This will then return an object that you can inspect.
   ...
 ```
 
-You can also use a literal
+You can also use literals
 
 ```cpp
 using namespace TinyJSON;
@@ -223,7 +223,18 @@ auto json = "[12,13,14]"_tj;
 ...
 delete json;
 ...
+```
 
+Or just use the string directly
+
+```cpp
+#define TJ_INCLUDE_STD_STRING 1
+#include "TinyJSON.h"
+using namespace TinyJSON;
+...
+// output a pretty JSON
+std::cout << "[12,13,14]"_tj_indent;
+...
 ```
 
 ### Write a JSON string
@@ -363,3 +374,4 @@ The whole number ranges are +9223372036854775807 and -9223372036854775806
 - [x] Run on linux/gcc/g++ or something other than visual studio.
      `g++ -std=c++11 -Wall -Wextra -Werror -O3 src/tinyJSON.cpp -o a.exe`
 - [] We need to add copy and move constructors to `TJValue` and the derived classes.
+- [] Add Macro(s) definitions like `TJ_INCLUDE_STD_STRING` for example.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ delete json;
 
 Or just use the string directly
 
+You can convert the json to 'pretty' indented json
+
 ```cpp
 #define TJ_INCLUDE_STD_STRING 1
 #include "TinyJSON.h"
@@ -234,6 +236,18 @@ using namespace TinyJSON;
 ...
 // output a pretty JSON
 std::cout << "[12,13,14]"_tj_indent;
+...
+```
+
+Or `minify` code.
+
+```cpp
+#define TJ_INCLUDE_STD_STRING 1
+#include "TinyJSON.h"
+using namespace TinyJSON;
+...
+// output a pretty JSON
+std::cout << "[12 , 13 , 14]"_tj_minify;
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For example ...
 ```cpp
 TinyJSON::write_options options = {};
 options.throw_exception = true;
-options.write_formating = TinyJSON::formating::none;
+options.write_formating = TinyJSON::formating::minify;
 
 try
 {
@@ -151,7 +151,7 @@ The parsing exception is `TinyJSON::TJParseException` and can be made optional i
 ```cpp
   TinyJSON::write_options options = {};
   options.throw_exception = true;
-  options.write_formating = TinyJSON::formating::none;
+  options.write_formating = TinyJSON::formating::minify;
 
   try
   {
@@ -277,7 +277,7 @@ The formating types are
 
 ```cpp
   TinyJSON::formating::indented
-  TinyJSON::formating::none
+  TinyJSON::formating::minify
 ```
 
 ### Objects

--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,7 @@ This shows how to pass options while parsing.
 
 ```cpp
 ...
-  auto jsonex = TinyJSON::TinyJSON::parse(R"({"number" : 12.e00})", {.throw_exception = true  });
+  auto jsonex = TinyJSON::TJ::parse(R"({"number" : 12.e00})", {.throw_exception = true  });
 ...
 ```
 
@@ -29,6 +29,6 @@ This test that the build works with c++ 11
 ...
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  auto jsonex = TinyJSON::TinyJSON::parse(R"({"number" : 12.e00})", options);
+  auto jsonex = TinyJSON::TJ::parse(R"({"number" : 12.e00})", options);
 ...
 ```

--- a/example/basic_parse.cpp
+++ b/example/basic_parse.cpp
@@ -11,13 +11,13 @@ int main()
     "string" : "Hello world"
   })";
 
-  if (!TinyJSON::TinyJSON::is_valid(json))
+  if (!TinyJSON::TJ::is_valid(json))
   {
     // this should have been valid!
     return -1;
   }
 
-  auto tjjson = TinyJSON::TinyJSON::parse(json);
+  auto tjjson = TinyJSON::TJ::parse(json);
   if(nullptr == tjjson)
   {
     return -1;

--- a/example/options.cpp
+++ b/example/options.cpp
@@ -20,7 +20,7 @@ int main()
     auto tjobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
     std::cout << "Parsed an object with " << tjobject->get_number_of_items() << " item(s)\n";
 
-    std::cout << "\nNo Indent dump:\n" << tjobject->dump(TinyJSON::formating::none) << "\n";
+    std::cout << "\nNo Indent dump:\n" << tjobject->dump(TinyJSON::formating::minify) << "\n";
   }
   else
   {

--- a/example/options.cpp
+++ b/example/options.cpp
@@ -6,7 +6,7 @@
  
 int main()
 {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
     "number" : 12,
     "string" : "Hello world"
   })");
@@ -35,7 +35,7 @@ int main()
   // throw an exception
   try
   {
-    auto jsonex = TinyJSON::TinyJSON::parse(R"({"number" : 12.e00})", {.throw_exception = true  });
+    auto jsonex = TinyJSON::TJ::parse(R"({"number" : 12.e00})", {.throw_exception = true  });
     std::cout << "There was an issue throwing an exceptions!";
     delete jsonex;  
     return -1;

--- a/example/options11.cpp
+++ b/example/options11.cpp
@@ -20,7 +20,7 @@ int main()
     auto tjobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
     std::cout << "Parsed an object with " << tjobject->get_number_of_items() << " item(s)\n";
 
-    std::cout << "\nNo Indent dump:\n" << tjobject->dump(TinyJSON::formating::none) << "\n";
+    std::cout << "\nNo Indent dump:\n" << tjobject->dump(TinyJSON::formating::minify) << "\n";
   }
   else
   {

--- a/example/options11.cpp
+++ b/example/options11.cpp
@@ -6,7 +6,7 @@
  
 int main()
 {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
     "number" : 12,
     "string" : "Hello world"
   })");
@@ -37,7 +37,7 @@ int main()
   {
     TinyJSON::parse_options options = {};
     options.throw_exception = true;
-    auto* jsonex = TinyJSON::TinyJSON::parse(R"({"number" : 12.e00})", options);
+    auto* jsonex = TinyJSON::TJ::parse(R"({"number" : 12.e00})", options);
     std::cout << "There was an issue throwing an exceptions!";
     delete jsonex;  
     return -1;

--- a/example/user_literals.cpp
+++ b/example/user_literals.cpp
@@ -1,0 +1,55 @@
+// Licensed to Florent Guelfucci under one or more agreements.
+// Florent Guelfucci licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#include <iostream>
+
+#define TJ_INCLUDE_STD_STRING 1
+#include "../src/TinyJSON.h"
+
+using namespace TinyJSON; 
+int main()
+{
+  auto json = R"({
+    "number" : 12,
+    "string" : "Hello world"
+  })";
+
+  if (!TJ::is_valid(json))
+  {
+    // this should have been valid!
+    return -1;
+  }
+
+  auto tjjson = R"({
+    "number" : 12,
+    "string" : "Hello world"
+  })"_tj;
+
+  if(nullptr == tjjson)
+  {
+    return -1;
+  }
+
+  if(tjjson->is_object())
+  {
+    auto tjobject = dynamic_cast<TJValueObject*>(tjjson);
+    std::cout << "Parsed an object with " << tjobject->get_number_of_items() << " item(s)\n";
+
+    std::cout << "\n====\nPretty dump:\n" << tjobject->dump() << "\n====\n";
+  }
+  else
+  {
+    std::cout << "There was an issue parsing the object";
+    delete tjjson;
+    return -1;
+  }
+  delete tjjson;
+
+  // output a pretty JSON
+  std::cout << "\n====\nPretty JSON Array text.\n" << "[12,13,14]"_tj_indent << "\n====\n";
+
+  // output a non-indented JSON
+  std::cout << "\n====\nNot indented JSON Array text.\n" << "[  12,   13,  14]"_tj_minify << "\n====\n";
+
+  return 0;
+}

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -406,7 +406,7 @@ namespace TinyJSON
   /// Protected Helper class
   class TJHelper
   {
-    friend TinyJSON;
+    friend TJ;
     friend TJMember;
     friend TJValue;
     friend TJValueArray;
@@ -2237,7 +2237,7 @@ namespace TinyJSON
   };  // Helper class
 
   ///////////////////////////////////////
-  /// TinyJSON
+  /// TJ
 
   /// <summary>
   /// Write a value to a file.
@@ -2246,7 +2246,7 @@ namespace TinyJSON
   /// <param name="root">the value we are writting</param>
   /// <param name="write_options">The options we will be using to write</param>
   /// <returns></returns>
-  bool TinyJSON::write_file(const TJCHAR* file_path, const TJValue& root, const write_options& write_options)
+  bool TJ::write_file(const TJCHAR* file_path, const TJValue& root, const write_options& write_options)
   {
     return internal_write_file(file_path, root, write_options);
   }
@@ -2257,7 +2257,7 @@ namespace TinyJSON
   /// <param name="source">The source file we are trying to parse.</param>
   /// <param name="parse_options">The option we want to use when parsing this.</param>
   /// <returns></returns>
-  TJValue* TinyJSON::parse_file(const TJCHAR* file_path, const parse_options& parse_options)
+  TJValue* TJ::parse_file(const TJCHAR* file_path, const parse_options& parse_options)
   {
     // sanity check
     if (nullptr == file_path)
@@ -2313,7 +2313,7 @@ namespace TinyJSON
   /// <param name="source">The source we are trying to parse.</param>
   /// <param name="options">The option we want to use when parsing this.</param>
   /// <returns></parse_options>
-  TJValue* TinyJSON::parse(const TJCHAR* source, const parse_options& parse_options)
+  TJValue* TJ::parse(const TJCHAR* source, const parse_options& parse_options)
   {
     return internal_parse(source, parse_options);
   }
@@ -2324,7 +2324,7 @@ namespace TinyJSON
   /// <param name="source"></param>
   /// <param name="parse_options"></param>
   /// <returns></returns>
-  bool TinyJSON::is_valid(const TJCHAR* source, const parse_options& parse_options)
+  bool TJ::is_valid(const TJCHAR* source, const parse_options& parse_options)
   {
     auto* tj_value = internal_parse(source, parse_options);
     auto is_valid = tj_value != nullptr;
@@ -2339,7 +2339,7 @@ namespace TinyJSON
   /// <param name="source"></param>
   /// <param name="parse_options"></param>
   /// <returns></returns>
-  TJValue* TinyJSON::internal_parse(const TJCHAR* source, const parse_options& parse_options)
+  TJValue* TJ::internal_parse(const TJCHAR* source, const parse_options& parse_options)
   {
     // sanity check
     ParseResult parse_result(parse_options);
@@ -2417,7 +2417,7 @@ namespace TinyJSON
   /// <param name="root">the value we are writting</param>
   /// <param name="write_options">The options we will be using to write</param>
   /// <returns></returns>
-  bool TinyJSON::internal_write_file(const TJCHAR* file_path, const TJValue& root, const write_options& write_options)
+  bool TJ::internal_write_file(const TJCHAR* file_path, const TJValue& root, const write_options& write_options)
   {
     WriteResult write_result(write_options);
 

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -2592,7 +2592,7 @@ namespace TinyJSON
     free_last_dump();
     switch (formating)
     {
-    case formating::none:
+    case formating::minify:
       {
         internal_dump_configuration configuration(formating, nullptr, 
           TJCHARPREFIX(","), 
@@ -2622,7 +2622,7 @@ namespace TinyJSON
   const TJCHAR* TJValue::dump_string() const
   {
     free_last_dump();
-    internal_dump_configuration configuration(formating::none, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false);
+    internal_dump_configuration configuration(formating::minify, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false);
     internal_dump(configuration, nullptr);
     _last_dump = configuration._buffer;
     return _last_dump;
@@ -2946,7 +2946,7 @@ namespace TinyJSON
     }
 
     delete [] value->_last_dump;
-    internal_dump_configuration configuration(formating::none, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false);
+    internal_dump_configuration configuration(formating::minify, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false);
     value->internal_dump(configuration, nullptr);
     value->_last_dump = configuration._buffer;
 

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -49,7 +49,7 @@ namespace TinyJSON
   // the various types of formating.
   enum class formating
   {
-    none,
+    minify,
     indented
   };
 
@@ -533,6 +533,21 @@ namespace TinyJSON
     delete tj;
     return json;
   }  
+
+  inline std::string operator ""_tj_minify(const TJCHAR * source, std::size_t)
+  {
+    parse_options options = {};
+    options.throw_exception = true;
+    auto* tj = TJ::parse(source, options);
+    if (nullptr == tj)
+    {
+      //  exception will throw.
+      return TJCHARPREFIX("");
+    }
+    std::string json(tj->dump(formating::minify));
+    delete tj;
+    return json;
+  }
   #endif
 } // TinyJSON
 #endif // !TJ_INCLUDED 

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -5,6 +5,15 @@
 #ifndef TJ_INCLUDED 
 #define TJ_INCLUDED
 
+// Assume that we do not want std::string
+#ifndef TJ_INCLUDE_STD_STRING
+#define TJ_INCLUDE_STD_STRING 0
+#endif
+
+#if TJ_INCLUDE_STD_STRING == 1
+#include <string>
+#endif
+
 // https://semver.org/
 // Semantic Versioning 2.0.0
 //   MAJOR version when you make incompatible API changes
@@ -502,11 +511,28 @@ namespace TinyJSON
 
 
   // user_literals
-  inline TJValue* operator ""_tj(const char* source, std::size_t)
+  inline TJValue* operator ""_tj(const TJCHAR * source, std::size_t)
   {
     parse_options options = {};
     options.throw_exception = true;
     return TJ::parse(source, options);
   }
+
+  #if TJ_INCLUDE_STD_STRING == 1
+  inline std::string operator ""_tj_indent(const TJCHAR * source, std::size_t)
+  {
+    parse_options options = {};
+    options.throw_exception = true;
+    auto* tj = TJ::parse(source, options);
+    if (nullptr == tj)
+    {
+      //  exception will throw.
+      return TJCHARPREFIX("");
+    }
+    std::string json(tj->dump(formating::indented));
+    delete tj;
+    return json;
+  }  
+  #endif
 } // TinyJSON
 #endif // !TJ_INCLUDED 

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -175,11 +175,12 @@ namespace TinyJSON
     void free_last_dump() const;
   };
 
+
   // The parser class
-  class TinyJSON
+  class TJ
   {
   public:
-    virtual ~TinyJSON() = default;
+    virtual ~TJ() = default;
 
     /// <summary>
     /// Return if the given source is valid or not.
@@ -234,11 +235,11 @@ namespace TinyJSON
     static bool internal_write_file(const TJCHAR* file_path, const TJValue& root, const write_options& write_options);
 
   private:
-    TinyJSON() = delete;
-    TinyJSON(TinyJSON&&) = delete;
-    TinyJSON(const TinyJSON&) = delete;
-    TinyJSON& operator=(const TinyJSON&) = delete;
-    TinyJSON& operator=(TinyJSON&&) = delete;
+    TJ() = delete;
+    TJ(TJ&&) = delete;
+    TJ(const TJ&) = delete;
+    TJ& operator=(const TJ&) = delete;
+    TJ& operator=(TJ&&) = delete;
   };
 
   // A TJMember is a key value pair, (name/value), that belong to an object.
@@ -498,5 +499,14 @@ namespace TinyJSON
     const unsigned int _fraction_exponent;
     const int _exponent;
   };
+
+
+  // user_literals
+  inline TJValue* operator ""_tj(const char* source, std::size_t)
+  {
+    parse_options options = {};
+    options.throw_exception = true;
+    return TJ::parse(source, options);
+  }
 } // TinyJSON
 #endif // !TJ_INCLUDED 

--- a/tests/testjsonchecker.cpp
+++ b/tests/testjsonchecker.cpp
@@ -67,7 +67,7 @@ TEST(JSONchecker, AllFiles)
     const auto& filename = file.path().string();
     try
     {
-      auto json = TinyJSON::TinyJSON::parse_file(filename.c_str(), options);
+      auto json = TinyJSON::TJ::parse_file(filename.c_str(), options);
       if (is_fail && json != nullptr)
       {
         EXPECT_TRUE(false) << "Expected Fail: " << std::filesystem::path(file.path()).filename();

--- a/tests/testtinyjson.cpp
+++ b/tests/testtinyjson.cpp
@@ -27,17 +27,17 @@ bool IsDerivedFrom() {
 }
 
 TEST(TestBasic, WeCanPassANullString) {
-  auto json = TinyJSON::TinyJSON::parse(nullptr);
+  auto json = TinyJSON::TJ::parse(nullptr);
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestBasic, WeCanPassANullFileName) {
-  auto json = TinyJSON::TinyJSON::parse_file(nullptr);
+  auto json = TinyJSON::TJ::parse_file(nullptr);
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestBasic, TheObjectInsideTheObjectDoesNotCloseProperly) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
    {
      "a" : { 
         "a" : "b"
@@ -47,7 +47,7 @@ TEST(TestBasic, TheObjectInsideTheObjectDoesNotCloseProperly) {
 }
 
 TEST(TestBasic, HaveEnEmptyObjectWithNothing) {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
   ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValueObject*>(json));
 
@@ -55,7 +55,7 @@ TEST(TestBasic, HaveEnEmptyObjectWithNothing) {
 }
 
 TEST(TestBasic, SpacesAreIgnored) {
-  auto json = TinyJSON::TinyJSON::parse(" {  }  ");
+  auto json = TinyJSON::TJ::parse(" {  }  ");
   ASSERT_NE(nullptr, json);
   ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValueObject*>(json));
 
@@ -63,12 +63,12 @@ TEST(TestBasic, SpacesAreIgnored) {
 }
 
 TEST(TestBasic, InvalidCommaAfterTheClosedObject) {
-  auto json = TinyJSON::TinyJSON::parse("{},");
+  auto json = TinyJSON::TJ::parse("{},");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestBasic, CommaBeforeTheStringIsNotAllowed) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   ,"a" : "a"
 }
@@ -80,7 +80,7 @@ TEST(TestBasic, CommaBeforeTheStringIsNotAllowed) {
 }
 
 TEST(TestBasic, CommaAfterTheLastStringIsNotAllowed) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : "a",
 }
@@ -92,7 +92,7 @@ TEST(TestBasic, CommaAfterTheLastStringIsNotAllowed) {
 }
 
 TEST(TestBasic, CheckForNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : null
 }
@@ -110,7 +110,7 @@ TEST(TestBasic, CheckForNull) {
 }
 
 TEST(TestBasic, WeRequireACommaBetweenStringValues) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : "a",
   "b" : "b"
@@ -124,7 +124,7 @@ TEST(TestBasic, WeRequireACommaBetweenStringValues) {
 TEST(TestBasic, WeRequireACommaBetweenValuesOfNumbersAndObjects) {
 
   // missing a comma after the number
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12,
   "b" : {}
@@ -138,7 +138,7 @@ TEST(TestBasic, WeRequireACommaBetweenValuesOfNumbersAndObjects) {
 TEST(TestBasic, TwoCommaBetweenElementsIsNotValid) {
 
   // missing a comma after the number
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12,,
   "b" : 13
@@ -149,7 +149,7 @@ TEST(TestBasic, TwoCommaBetweenElementsIsNotValid) {
 }
 
 TEST(TestBasic, CheckForDifferentValueTypes) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : null,
   "b" : true,
@@ -188,7 +188,7 @@ TEST(TestBasic, CheckForDifferentValueTypes) {
 }
 
 TEST(TestBasic, ObjectInsideAnObject) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : {
     "b" : true
@@ -218,7 +218,7 @@ TEST(TestBasic, ObjectInsideAnObject) {
 }
 
 TEST(TestBasic, ObjectMultipleDepth) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : true,
   "b" : {
@@ -257,7 +257,7 @@ TEST(TestBasic, ObjectMultipleDepth) {
 // this is the test data take from https://github.com/stephenberry/json_performance/blob/main/README.md
 // we have to be able to read this ...
 TEST(TestBasic, ReadPerformanceBlob) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
    "fixed_object": {
       "int_array": [0, 1, 2, 3, 4, 5, 6],
@@ -306,7 +306,7 @@ TEST(TestBasic, ReadPerformanceBlob) {
 }
 
 TEST(TestBasic, TrueBooleanInStringIsValid) {
-  auto json = TinyJSON::TinyJSON::parse("true");
+  auto json = TinyJSON::TJ::parse("true");
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_true());
 
@@ -323,7 +323,7 @@ TEST(TestBasic, IntNumberInStringIsValid) {
   for (auto& number : values)
   {
     std::string s_json = " " + number + " ";
-    auto json = TinyJSON::TinyJSON::parse(s_json.c_str());
+    auto json = TinyJSON::TJ::parse(s_json.c_str());
     ASSERT_NE(nullptr, json);
     ASSERT_TRUE(json->is_number());
 
@@ -335,7 +335,7 @@ TEST(TestBasic, IntNumberInStringIsValid) {
 }
 
 TEST(TestBasic, FalseBooleanInStringIsValid) {
-  auto json = TinyJSON::TinyJSON::parse("false");
+  auto json = TinyJSON::TJ::parse("false");
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_false());
 
@@ -343,7 +343,7 @@ TEST(TestBasic, FalseBooleanInStringIsValid) {
 }
 
 TEST(TestBasic, NullInStringIsValid) {
-  auto json = TinyJSON::TinyJSON::parse("null");
+  auto json = TinyJSON::TJ::parse("null");
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_null());
 
@@ -351,7 +351,7 @@ TEST(TestBasic, NullInStringIsValid) {
 }
 
 TEST(TestBasic, NothingIsJustAnEmptyString) {
-  auto json = TinyJSON::TinyJSON::parse("");
+  auto json = TinyJSON::TJ::parse("");
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_string());
   ASSERT_STREQ("", json->dump_string());
@@ -360,7 +360,7 @@ TEST(TestBasic, NothingIsJustAnEmptyString) {
 }
 
 TEST(TestBasic, NothingIsJustAnEmptyStringWithSpaces) {
-  auto json = TinyJSON::TinyJSON::parse(R"(   
+  auto json = TinyJSON::TJ::parse(R"(   
 
 
 
@@ -376,7 +376,7 @@ TEST(TestBasic, NothingIsJustAnEmptyStringWithSpaces) {
 }
 
 TEST(TestBasic, StringValueIsValid) {
-  auto json = TinyJSON::TinyJSON::parse(R"("Hello")");
+  auto json = TinyJSON::TJ::parse(R"("Hello")");
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_string());
   ASSERT_STREQ("Hello", json->dump_string());
@@ -385,7 +385,7 @@ TEST(TestBasic, StringValueIsValid) {
 }
 
 TEST(TestBasic, StringValueIsValidWithSpaces) {
-  auto json = TinyJSON::TinyJSON::parse(R"(   
+  auto json = TinyJSON::TJ::parse(R"(   
 
 
 
@@ -401,7 +401,7 @@ TEST(TestBasic, StringValueIsValidWithSpaces) {
 }
 
 TEST(TestBasic, ValueInObjectOverwriteEachother) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
    {
 "a" : 12,
 "a" : 24
@@ -423,7 +423,7 @@ TEST(TestBasic, ValueInObjectOverwriteEachother) {
 }
 
 TEST(TestBasic, ValueInObjectOverwriteEachotherInsideArray) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
    {
 "a" : [12,24,48],
 "a" : 24
@@ -445,7 +445,7 @@ TEST(TestBasic, ValueInObjectOverwriteEachotherInsideArray) {
 }
 
 TEST(TestBasic, ValueInObjectOverwriteEachotherInsideArray2) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   { 
     "a" : 12,
@@ -476,28 +476,28 @@ TEST(TestBasic, WeReachedMaxDepthMixed) {
   TinyJSON::parse_options options = {};
   options.throw_exception = false;
   options.max_depth = 4;
-  auto json = TinyJSON::TinyJSON::parse(R"({"a":[12,{"c":{}}]})", options);
+  auto json = TinyJSON::TJ::parse(R"({"a":[12,{"c":{}}]})", options);
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestBasic, Rfc4627WantsAnObjectOrAnArrayAndThisIsNeither) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
-  auto json = TinyJSON::TinyJSON::parse("true", options);
+  auto json = TinyJSON::TJ::parse("true", options);
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestBasic, Rfc4627WantsAnObjectOrAnArrayAndThisIsEmpty) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
-  auto json = TinyJSON::TinyJSON::parse("     ", options);
+  auto json = TinyJSON::TJ::parse("     ", options);
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestBasic, Rfc4627WantsAnObjectOrAnArrayAndThisIsAnObject) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
-  auto json = TinyJSON::TinyJSON::parse("{}", options);
+  auto json = TinyJSON::TJ::parse("{}", options);
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_object());
   delete json;
@@ -507,7 +507,7 @@ TEST(TestBasic, Rfc4627WantsAnObjectOrAnArrayAndThisIsAnArray) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
   options.max_depth = 4;
-  auto json = TinyJSON::TinyJSON::parse("[12,13,14]", options);
+  auto json = TinyJSON::TJ::parse("[12,13,14]", options);
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(json->is_array());
   delete json;
@@ -517,46 +517,64 @@ TEST(TestBasic, Rfc4627ArrayIsValid) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
   options.max_depth = 4;
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("[12,13,14]", options));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("[12,13,14]", options));
 }
 
 TEST(TestBasic, Rfc4627ObjectIsValid) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
   options.max_depth = 4;
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("{\"a\" : 12}", options));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("{\"a\" : 12}", options));
 }
 
 TEST(TestBasic, Rfc4627IsNotValidAsItMustBeAnArrayOrObject) {
   TinyJSON::parse_options options = {};
   options.specification = TinyJSON::parse_options::rfc4627;
   options.max_depth = 4;
-  ASSERT_FALSE(TinyJSON::TinyJSON::is_valid("true", options));
+  ASSERT_FALSE(TinyJSON::TJ::is_valid("true", options));
 }
 
 TEST(TestBasic, SimpleObjectIsValid) {
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("{}"));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("{}"));
 }
 
 TEST(TestBasic, TrueInRootIsValid) {
   TinyJSON::parse_options options = {};
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("true"));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("true"));
 }
 
 TEST(TestBasic, FalseInRootIsValid) {
   TinyJSON::parse_options options = {};
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("false"));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("false"));
 }
 
 TEST(TestBasic, NullInRootIsValid) {
   TinyJSON::parse_options options = {};
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("null"));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("null"));
 }
 
 TEST(TestBasic, ObjectIsValid) {
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("{\"a\" : 12}"));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("{\"a\" : 12}"));
 }
 
 TEST(TestBasic, ArrayIsValid) {
-  ASSERT_TRUE(TinyJSON::TinyJSON::is_valid("[12,13,14]"));
+  ASSERT_TRUE(TinyJSON::TJ::is_valid("[12,13,14]"));
+}
+
+TEST(TestBasic, UserLiteralsArray)
+{
+  using namespace TinyJSON;
+  auto json = "[12,13,14]"_tj;
+  ASSERT_NE(nullptr, json);
+  ASSERT_TRUE(json->is_array());
+
+  const auto tjarray = dynamic_cast<TJValueArray*>(json);
+  ASSERT_NE(nullptr, tjarray);
+
+  ASSERT_EQ(3, tjarray->get_number_of_items());
+  ASSERT_TRUE(12, tjarray->at(0)->is_number());
+  ASSERT_TRUE(13, tjarray->at(1)->is_number());
+  ASSERT_TRUE(4, tjarray->at(2)->is_number());
+
+  delete json;
 }

--- a/tests/testtinyjson.cpp
+++ b/tests/testtinyjson.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 #include <type_traits>
 
+#define TJ_INCLUDE_STD_STRING 1
 #define TJ_USE_CHAR 1
 #include "../src/TinyJSON.h"
 
@@ -577,4 +578,16 @@ TEST(TestBasic, UserLiteralsArray)
   ASSERT_TRUE(4, tjarray->at(2)->is_number());
 
   delete json;
+}
+
+TEST(TestBasic, UserLiteralsArrayOutputToIndented)
+{
+  using namespace TinyJSON;
+  auto json = "[12,13,14]"_tj_indent;
+
+  ASSERT_STREQ(R"([
+  12,
+  13,
+  14
+])", json.c_str());
 }

--- a/tests/testtinyjsonarrays.cpp
+++ b/tests/testtinyjsonarrays.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestArrays, MakeSureThatEmptyStringIsKinkOfValueArray) {
-  auto json = TinyJSON::TinyJSON::parse("[]");
+  auto json = TinyJSON::TJ::parse("[]");
   ASSERT_NE(nullptr, json);
   ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValue*>(json));
   auto jarray = dynamic_cast<TinyJSON::TJValueArray*>(json);
@@ -16,29 +16,29 @@ TEST(TestArrays, MakeSureThatEmptyStringIsKinkOfValueArray) {
 }
 
 TEST(TestArrays, ArrayOpensButNeverCloses) {
-  auto json = TinyJSON::TinyJSON::parse("[");
+  auto json = TinyJSON::TJ::parse("[");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestArrays, ArrayOpensAndHasValuesButNeverCloses) {
-  auto json = TinyJSON::TinyJSON::parse(R"([
+  auto json = TinyJSON::TJ::parse(R"([
     "a", "b"
     )");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestArrays, ArrayHasTwoColons) {
-  auto json = TinyJSON::TinyJSON::parse("[ 1,2,3,,4,5]");
+  auto json = TinyJSON::TJ::parse("[ 1,2,3,,4,5]");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestArrays, ArrayHasTwoColonsAtTheEnd) {
-  auto json = TinyJSON::TinyJSON::parse("[ 1,2,3,,]");
+  auto json = TinyJSON::TJ::parse("[ 1,2,3,,]");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestArrays, EmptyArrayInObject) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" : []
 }
@@ -56,7 +56,7 @@ TEST(TestArrays, EmptyArrayInObject) {
 }
 
 TEST(TestArrays, ArrayInObjectIsAfterMissingColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" [
         42, 12
@@ -68,7 +68,7 @@ TEST(TestArrays, ArrayInObjectIsAfterMissingColon) {
 }
 
 TEST(TestArrays, EmptyArrayOfNumbersHasNoItems) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
 ]
 )"
@@ -80,7 +80,7 @@ TEST(TestArrays, EmptyArrayOfNumbersHasNoItems) {
 }
 
 TEST(TestArrays, ArrayOfNumbersHasCorrectNumberOfItems) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12, 13, 14
 ]
@@ -93,7 +93,7 @@ TEST(TestArrays, ArrayOfNumbersHasCorrectNumberOfItems) {
 }
 
 TEST(TestArrays, EmptyArrayInSideArrayHasNoItemsInIt) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     [
       [
       ]
@@ -116,7 +116,7 @@ TEST(TestArrays, EmptyArrayInSideArrayHasNoItemsInIt) {
 }
 
 TEST(TestArrays, CheckThatValueIsArray) {
-  auto json = TinyJSON::TinyJSON::parse("[]");
+  auto json = TinyJSON::TJ::parse("[]");
   ASSERT_NE(nullptr, json);
 
   ASSERT_FALSE(json->is_object());
@@ -130,7 +130,7 @@ TEST(TestArrays, CheckThatValueIsArray) {
 }
 
 TEST(TestArrays, TryingToGetAnItemThatDoesNotExitReturnsNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12, 13, 14
 ]
@@ -146,7 +146,7 @@ TEST(TestArrays, TryingToGetAnItemThatDoesNotExitReturnsNull) {
 }
 
 TEST(TestArrays, TryingToGetANegativeItemReturnsNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12, 13, 14
 ]
@@ -163,7 +163,7 @@ TEST(TestArrays, TryingToGetANegativeItemReturnsNull) {
 }
 
 TEST(TestArrays, ItemsInArrayMustBeSeparatedByCommaNumbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12
   13
@@ -174,7 +174,7 @@ TEST(TestArrays, ItemsInArrayMustBeSeparatedByCommaNumbers) {
 }
 
 TEST(TestArrays, ItemsInArrayMustBeSeparatedByCommaWithStrings) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "A"
   "B"
@@ -185,7 +185,7 @@ TEST(TestArrays, ItemsInArrayMustBeSeparatedByCommaWithStrings) {
 }
 
 TEST(TestArrays, ItemsInArrayMustBeSeparatedByCommaWithNumbersAndStrings) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12
   "B"
@@ -196,7 +196,7 @@ TEST(TestArrays, ItemsInArrayMustBeSeparatedByCommaWithNumbersAndStrings) {
 }
 
 TEST(TestArrays, ArrayHasACommaButThenTheArrayEnds) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12,
   "B",

--- a/tests/testtinyjsonbooleans.cpp
+++ b/tests/testtinyjsonbooleans.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestBooleans, BooleanIsAfterMissingColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" true
     }
@@ -16,7 +16,7 @@ TEST(TestBooleans, BooleanIsAfterMissingColon) {
 }
 
 TEST(TestBooleans, CheckForTrue) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : true
 }
@@ -37,7 +37,7 @@ TEST(TestBooleans, CheckForTrue) {
 }
 
 TEST(TestBooleans, CheckForFalse) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : false
 }
@@ -58,7 +58,7 @@ TEST(TestBooleans, CheckForFalse) {
 }
 
 TEST(TestBooleans, TrueBooleanNotSpelledProperly1) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : t
     }
@@ -68,7 +68,7 @@ TEST(TestBooleans, TrueBooleanNotSpelledProperly1) {
 }
 
 TEST(TestBooleans, TrueBooleanNotSpelledProperly2) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : tr
     }
@@ -78,7 +78,7 @@ TEST(TestBooleans, TrueBooleanNotSpelledProperly2) {
 }
 
 TEST(TestBooleans, TrueBooleanNotSpelledProperly3) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : tru
     }
@@ -88,7 +88,7 @@ TEST(TestBooleans, TrueBooleanNotSpelledProperly3) {
 }
 
 TEST(TestBooleans, FalseBooleanNotSpelledProperly1) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : f
     }
@@ -98,7 +98,7 @@ TEST(TestBooleans, FalseBooleanNotSpelledProperly1) {
 }
 
 TEST(TestBooleans, FalseBooleanNotSpelledProperly2) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : fa
     }
@@ -108,7 +108,7 @@ TEST(TestBooleans, FalseBooleanNotSpelledProperly2) {
 }
 
 TEST(TestBooleans, FalseBooleanNotSpelledProperly3) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : fal
     }
@@ -118,7 +118,7 @@ TEST(TestBooleans, FalseBooleanNotSpelledProperly3) {
 }
 
 TEST(TestBooleans, FalseBooleanNotSpelledProperly4) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : fals
     }
@@ -128,7 +128,7 @@ TEST(TestBooleans, FalseBooleanNotSpelledProperly4) {
 }
 
 TEST(TestBooleans, CheckThatValueIsBooleanAndCorrectValue) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : false,
       "b" : true
@@ -166,7 +166,7 @@ TEST(TestBooleans, CheckThatValueIsBooleanAndCorrectValue) {
 }
 
 TEST(TestBooleans, CheckThatValueIsBooleanAndCorrectValueInArray) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     [
       false,
       true

--- a/tests/testtinyjsondump.cpp
+++ b/tests/testtinyjsondump.cpp
@@ -33,7 +33,7 @@ TEST(TestDump, EmptyArrayNoIndent) {
   auto json = TinyJSON::TJ::parse("[]");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ("[]", text);
@@ -45,7 +45,7 @@ TEST(TestDump, EmptyObjectNoIndent) {
   auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ("{}", text);
@@ -57,7 +57,7 @@ TEST(TestDump, EmptyArrayOfNumbersNoIndent) {
   auto json = TinyJSON::TJ::parse("[12,13,14]");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ("[12,13,14]", text);
@@ -68,7 +68,7 @@ TEST(TestDump, EmptyArrayOfFloatNumbersNoIndent) {
   auto json = TinyJSON::TJ::parse("[  1.2,  1.03 , 0.14 ]");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ("[1.2,1.03,0.14]", text);
@@ -170,7 +170,7 @@ TEST(TestDump, EmptyArrayOfVariousNotIndented) {
 ])");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ("[12,true,null,false]", text);
@@ -202,7 +202,7 @@ TEST(TestDump, SimpleObjectWithNumbersNoIntent) {
 })");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"({"a":12,"b":14})", text);
@@ -308,7 +308,7 @@ TEST(TestDump, ThreeDeepArrayWithNumbersAndStringNotIndented) {
 ])");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"([12,[13,[14,15,"Hello"]],"World",3.1416])", text);

--- a/tests/testtinyjsondump.cpp
+++ b/tests/testtinyjsondump.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestDump, EmptyArray) {
-  auto json = TinyJSON::TinyJSON::parse("[]");
+  auto json = TinyJSON::TJ::parse("[]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::indented);
@@ -18,7 +18,7 @@ TEST(TestDump, EmptyArray) {
 }
 
 TEST(TestDump, EmptyObject) {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::indented);
@@ -30,7 +30,7 @@ TEST(TestDump, EmptyObject) {
 }
 
 TEST(TestDump, EmptyArrayNoIndent) {
-  auto json = TinyJSON::TinyJSON::parse("[]");
+  auto json = TinyJSON::TJ::parse("[]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -42,7 +42,7 @@ TEST(TestDump, EmptyArrayNoIndent) {
 }
 
 TEST(TestDump, EmptyObjectNoIndent) {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -54,7 +54,7 @@ TEST(TestDump, EmptyObjectNoIndent) {
 }
 
 TEST(TestDump, EmptyArrayOfNumbersNoIndent) {
-  auto json = TinyJSON::TinyJSON::parse("[12,13,14]");
+  auto json = TinyJSON::TJ::parse("[12,13,14]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -65,7 +65,7 @@ TEST(TestDump, EmptyArrayOfNumbersNoIndent) {
 }
 
 TEST(TestDump, EmptyArrayOfFloatNumbersNoIndent) {
-  auto json = TinyJSON::TinyJSON::parse("[  1.2,  1.03 , 0.14 ]");
+  auto json = TinyJSON::TJ::parse("[  1.2,  1.03 , 0.14 ]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -76,7 +76,7 @@ TEST(TestDump, EmptyArrayOfFloatNumbersNoIndent) {
 }
 
 TEST(TestDump, EmptyArrayOfFloatNumbers) {
-  auto json = TinyJSON::TinyJSON::parse("[  1.2,  1.03 , 0.14 ]");
+  auto json = TinyJSON::TJ::parse("[  1.2,  1.03 , 0.14 ]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::indented);
@@ -91,7 +91,7 @@ TEST(TestDump, EmptyArrayOfFloatNumbers) {
 }
 
 TEST(TestDump, EmptyArrayOfNumbers) {
-  auto json = TinyJSON::TinyJSON::parse("[12,13,14]");
+  auto json = TinyJSON::TJ::parse("[12,13,14]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::indented);
@@ -115,7 +115,7 @@ TEST(TestDump, AnIntNumberByItSelf) {
   values.push_back("-1");
   for (auto& value : values)
   {
-    auto json = TinyJSON::TinyJSON::parse(value.c_str());
+    auto json = TinyJSON::TJ::parse(value.c_str());
     ASSERT_NE(nullptr, json);
 
     const auto& text = json->dump(TinyJSON::formating::indented);
@@ -145,7 +145,7 @@ TEST(TestDump, AnIntNumberByItSelf2) {
 }
 
 TEST(TestDump, EmptyArrayOfVariousValues) {
-  auto json = TinyJSON::TinyJSON::parse("[ 12,true,null, false ]");
+  auto json = TinyJSON::TJ::parse("[ 12,true,null, false ]");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::indented);
@@ -162,7 +162,7 @@ TEST(TestDump, EmptyArrayOfVariousValues) {
 }
 
 TEST(TestDump, EmptyArrayOfVariousNotIndented) {
-  auto json = TinyJSON::TinyJSON::parse(R"([
+  auto json = TinyJSON::TJ::parse(R"([
   12,
   true,
   null,
@@ -184,7 +184,7 @@ TEST(TestDump, BooleanByItSelf) {
   values.push_back("false");
   for (auto& value : values)
   {
-    auto json = TinyJSON::TinyJSON::parse(value.c_str());
+    auto json = TinyJSON::TJ::parse(value.c_str());
     ASSERT_NE(nullptr, json);
 
     const auto& text = json->dump(TinyJSON::formating::indented);
@@ -196,7 +196,7 @@ TEST(TestDump, BooleanByItSelf) {
 }
 
 TEST(TestDump, SimpleObjectWithNumbersNoIntent) {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
   "a"  : 12,
   "b" : 14
 })");
@@ -210,7 +210,7 @@ TEST(TestDump, SimpleObjectWithNumbersNoIntent) {
 }
 
 TEST(TestDump, SimpleObjectWithNumbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
   "a"  : 12,
   "b" : 14
 })");
@@ -227,7 +227,7 @@ TEST(TestDump, SimpleObjectWithNumbers) {
 }
 
 TEST(TestDump, ObjectInObjectWithNumbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
   "a"  : 12,
   "b" : {
     "aa"  : 12,
@@ -250,7 +250,7 @@ TEST(TestDump, ObjectInObjectWithNumbers) {
 }
 
 TEST(TestDump, ArrayInArrayWithNumbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"([
+  auto json = TinyJSON::TJ::parse(R"([
   12,
   [12,13]
 ])");
@@ -270,7 +270,7 @@ TEST(TestDump, ArrayInArrayWithNumbers) {
 }
 
 TEST(TestDump, ThreeDeepArrayWithNumbersAndString) {
-  auto json = TinyJSON::TinyJSON::parse(R"([
+  auto json = TinyJSON::TJ::parse(R"([
   12,
   [13,
   [14,15,"Hello"]
@@ -299,7 +299,7 @@ TEST(TestDump, ThreeDeepArrayWithNumbersAndString) {
 }
 
 TEST(TestDump, ThreeDeepArrayWithNumbersAndStringNotIndented) {
-  auto json = TinyJSON::TinyJSON::parse(R"([
+  auto json = TinyJSON::TJ::parse(R"([
   12,
   [13,
   [14,15,"Hello"]
@@ -316,7 +316,7 @@ TEST(TestDump, ThreeDeepArrayWithNumbersAndStringNotIndented) {
 }
 
 TEST(TestDump, ThreeDeepObjectWithNumbersAndString) {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
   "a":12,
   "b":{"aa":13,
   "bb":{"aaa":14,"bbb":15,"ccc": "Hello"}
@@ -349,7 +349,7 @@ TEST(TestDump, StringByItSelf) {
   values.push_back(R"("Hello With Spaces")");
   for (auto& value : values)
   {
-    auto json = TinyJSON::TinyJSON::parse(value.c_str());
+    auto json = TinyJSON::TJ::parse(value.c_str());
     ASSERT_NE(nullptr, json);
 
     const auto& text = json->dump(TinyJSON::formating::indented);
@@ -372,7 +372,7 @@ TEST(TestDump, AFloatNumberByItSelf) {
   values.push_back("-42.789");
   for (auto& value : values)
   {
-    auto json = TinyJSON::TinyJSON::parse(value.c_str());
+    auto json = TinyJSON::TJ::parse(value.c_str());
     ASSERT_NE(nullptr, json);
     const auto& text = json->dump(TinyJSON::formating::indented);
     ASSERT_NE(nullptr, text);
@@ -392,7 +392,7 @@ TEST(TestDump, AnExponentNumberByItSelf) {
   values.push_back("-2.00001e+24");
   for (auto& value : values)
   {
-    auto json = TinyJSON::TinyJSON::parse(value.c_str());
+    auto json = TinyJSON::TJ::parse(value.c_str());
     ASSERT_NE(nullptr, json);
     const auto& text = json->dump(TinyJSON::formating::indented);
     ASSERT_NE(nullptr, text);
@@ -403,7 +403,7 @@ TEST(TestDump, AnExponentNumberByItSelf) {
 }
 
 TEST(TestDump, DumpOfAStringWillExcapeTheNewLine) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\nAnd this is a new line")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\nAnd this is a new line")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::indented);

--- a/tests/testtinyjsonexceptions.cpp
+++ b/tests/testtinyjsonexceptions.cpp
@@ -9,7 +9,7 @@ TEST(TestException, IfWeHaveNoExceptionWeDoNotThrow) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_NO_THROW( json = TinyJSON::TinyJSON::parse("[12,13,14]", options));
+  EXPECT_NO_THROW( json = TinyJSON::TJ::parse("[12,13,14]", options));
   delete json;
 }
 
@@ -17,7 +17,7 @@ TEST(TestException, ParseExceptionMessageIsSetProperly) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_NO_THROW(json = TinyJSON::TinyJSON::parse("[12,13,14]", options));
+  EXPECT_NO_THROW(json = TinyJSON::TJ::parse("[12,13,14]", options));
   delete json;
 }
 
@@ -43,134 +43,134 @@ TEST(TestException, CopyConstructorParseException) {
 TEST(TestException, EscapedTabCharacterInString) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Tab\tin string\"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[\"Tab\tin string\"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, EscapedReturnCharacterInString) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Return\rin string\"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[\"Return\rin string\"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, EscapedLineFeedCharacterInString) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Line Feed\nin string\"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[\"Line Feed\nin string\"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, EscapedFormFeedCharacterInString) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Form Feed\fin string\"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[\"Form Feed\fin string\"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, EscapedBackSpaceCharacterInString) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"BackSpace\bin string\"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[\"BackSpace\bin string\"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, SingleEscapeCharacterInString) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[\"Single Escape \\ \"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[\"Single Escape \\ \"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, TheStringIsNotClosed) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("\"Not Closedd", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("\"Not Closedd", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, CommaAtTheEndOfObject) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("{\"a\" : 12,}", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("{\"a\" : 12,}", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, CommaAtTheEndOfArray) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[12,]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[12,]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, UnExpectedCommaInObject) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("{,}", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("{,}", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, UnExpectedCommaInArray) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[,]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[,]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, MissingCommaBetweenItemsInObject) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("{\"a\" : 12 \"b\" : 12}", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("{\"a\" : 12 \"b\" : 12}", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, MissingCommaBetweenItemsInArray) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[12 \"a\"]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[12 \"a\"]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, UnExpectedCharacterInObject) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("{ % }", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("{ % }", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, UnExpectedEndOfStringWhileParsingObject) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("{", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("{", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, UnExpectedEndOfStringWhileParsingArray) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, BadTrue) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[tru]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[tru]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, BadFalse) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[fals]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[fals]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, BadNull) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[nul]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[nul]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, MissingColonInObject) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse(R"({ "Missing colon" null })", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse(R"({ "Missing colon" null })", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, InvalidNumberWithLeadingZero) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[0123]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[0123]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, ExponentsWithZeroDoNotThrow) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_NO_THROW(json = TinyJSON::TinyJSON::parse("[1e00]", options));
+  EXPECT_NO_THROW(json = TinyJSON::TJ::parse("[1e00]", options));
   delete json;
 }
 
@@ -179,7 +179,7 @@ TEST(TestException, WeReachedMaxDepthOfObjects) {
   options.throw_exception = true;
   options.max_depth = 4;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_THROW(json = TinyJSON::TinyJSON::parse(R"({"a":{"b":{"c":{}}}})", options), TinyJSON::TJParseException);
+  EXPECT_THROW(json = TinyJSON::TJ::parse(R"({"a":{"b":{"c":{}}}})", options), TinyJSON::TJParseException);
   delete json;
 }
 
@@ -188,7 +188,7 @@ TEST(TestException, WeReachedMaxDepthOfArrays) {
   options.throw_exception = true;
   options.max_depth = 4;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_THROW(json = TinyJSON::TinyJSON::parse("[12,[13,[14,[]]]]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(json = TinyJSON::TJ::parse("[12,[13,[14,[]]]]", options), TinyJSON::TJParseException);
   delete json;
 }
 
@@ -197,7 +197,7 @@ TEST(TestException, WeReachedMaxDepthMixed) {
   options.throw_exception = true;
   options.max_depth = 4;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_THROW(json = TinyJSON::TinyJSON::parse(R"({"a":[12,{"c":{}}]})", options), TinyJSON::TJParseException);
+  EXPECT_THROW(json = TinyJSON::TJ::parse(R"({"a":[12,{"c":{}}]})", options), TinyJSON::TJParseException);
   delete json;
 }
 
@@ -206,48 +206,48 @@ TEST(TestException, Rfc4627WantsAnObjectOrAnArray) {
   options.throw_exception = true;
   options.specification = TinyJSON::parse_options::rfc4627;
   TinyJSON::TJValue* json = nullptr;
-  EXPECT_THROW(json = TinyJSON::TinyJSON::parse("true", options), TinyJSON::TJParseException);
+  EXPECT_THROW(json = TinyJSON::TJ::parse("true", options), TinyJSON::TJParseException);
   delete json;
 }
 
 TEST(TestException, WeCannotHaveMoreThanOneItemInRoot) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("{},[]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("{},[]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, UnexpectedTokenWhileLookingForValue) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse(R"({"a" : Value)", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse(R"({"a" : Value)", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, ExponentDoesNotHaveANumber) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[0e]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[0e]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, ExponentDoesNotHaveANumberButHasNegativeSign) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[0e-]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[0e-]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, ExponentDoesNotHaveANumberButHasPositiveSign) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("[0e+]", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("[0e+]", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, FractionIsMissingNumberBeforExponent) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("12.e2", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("12.e2", options), TinyJSON::TJParseException);
 }
 
 TEST(TestException, FractionIsMissingNumber) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  EXPECT_THROW(TinyJSON::TinyJSON::parse("12.", options), TinyJSON::TJParseException);
+  EXPECT_THROW(TinyJSON::TJ::parse("12.", options), TinyJSON::TJParseException);
 }

--- a/tests/testtinyjsonexponents.cpp
+++ b/tests/testtinyjsonexponents.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestExponents, FractionsWithLeadingZeros) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 62001e-3,
   "b" : 120012e-4,
@@ -39,7 +39,7 @@ TEST(TestExponents, FractionsWithLeadingZeros) {
 }
 
 TEST(TestExponents, InvalidWholeNumberWithExponent) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.e2
 }
@@ -49,7 +49,7 @@ TEST(TestExponents, InvalidWholeNumberWithExponent) {
 }
 
 TEST(TestExponents, InvalidMissingPositiveExponent) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.2e
 }
@@ -59,7 +59,7 @@ TEST(TestExponents, InvalidMissingPositiveExponent) {
 }
 
 TEST(TestExponents, InvalidMissingNegativeExponent) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.2-e
 }
@@ -71,7 +71,7 @@ TEST(TestExponents, InvalidMissingNegativeExponent) {
 TEST(TestExponents, ExponentCanBeZero) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "number" : 12e0
 }
@@ -92,7 +92,7 @@ TEST(TestExponents, ExponentCanBeZero) {
 TEST(TestExponents, NegativeExponentCanBeZero) {
   TinyJSON::parse_options options = {};
   options.throw_exception = true;
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "number" : 12e-000
 }
@@ -111,7 +111,7 @@ TEST(TestExponents, NegativeExponentCanBeZero) {
 }
 
 TEST(TestExponents, FractionNUmbersWithExponentIsActuallyWholeNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.3e1,
   "b" : 12.1e2,
@@ -139,7 +139,7 @@ TEST(TestExponents, FractionNUmbersWithExponentIsActuallyWholeNumber) {
 }
 
 TEST(TestExponents, FractionNUmbersWithExponentIsActuallyWholeNumberWithPlusSign) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.1e+1,
   "b" : 12.1e+2,
@@ -167,7 +167,7 @@ TEST(TestExponents, FractionNUmbersWithExponentIsActuallyWholeNumberWithPlusSign
 }
 
 TEST(TestExponents, FractionNUmbersWithExponentRemoveUnusedExponent) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 123.456e2,
   "b" : -123.456e2,
@@ -200,7 +200,7 @@ TEST(TestExponents, FractionNUmbersWithExponentRemoveUnusedExponent) {
 }
 
 TEST(TestExponents, ExponentWithNoFraction) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12e3
 }
@@ -218,7 +218,7 @@ TEST(TestExponents, ExponentWithNoFraction) {
 }
 
 TEST(TestExponents, NegativeExponentDoesNotAlwaysMakeFraction) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12000e-3
 }
@@ -236,7 +236,7 @@ TEST(TestExponents, NegativeExponentDoesNotAlwaysMakeFraction) {
 }
 
 TEST(TestExponents, LargeExponentIsConvertedToSingleWholeNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 123.045e+25,
   "b" : 678.09e+25,
@@ -269,7 +269,7 @@ TEST(TestExponents, LargeExponentIsConvertedToSingleWholeNumber) {
 }
 
 TEST(TestExponents, TinyNumberWithLargeExponentShiftsEnoughToBecomeANumberAgain) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.00000000000000000001e+24
 }
@@ -287,7 +287,7 @@ TEST(TestExponents, TinyNumberWithLargeExponentShiftsEnoughToBecomeANumberAgain)
 }
 
 TEST(TestExponents, TinyNumberWithLargeExponentShiftsEnoughToBecomeFloatNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.00000000000000000001e+18
 }
@@ -305,7 +305,7 @@ TEST(TestExponents, TinyNumberWithLargeExponentShiftsEnoughToBecomeFloatNumber) 
 }
 
 TEST(TestExponents, NumberJustShiftsEnoughToBecomeANumberAgain) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.00001000000000000001e+18
 }
@@ -323,7 +323,7 @@ TEST(TestExponents, NumberJustShiftsEnoughToBecomeANumberAgain) {
 }
 
 TEST(TestExponents, ShortNumberWithLongPositiveExponentShiftsEnoughToBecomeANumberAgain) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.00001e+24
 }
@@ -341,7 +341,7 @@ TEST(TestExponents, ShortNumberWithLongPositiveExponentShiftsEnoughToBecomeANumb
 }
 
 TEST(TestExponents, PositiveExponentNumberCannotBeConvertedToWholeNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 2.00001e+24
 }
@@ -359,7 +359,7 @@ TEST(TestExponents, PositiveExponentNumberCannotBeConvertedToWholeNumber) {
 }
 
 TEST(TestExponents, PositiveExponentOfNegativeNumberNumberCannotBeConvertedToWholeNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : -2.00001e+24
 }
@@ -377,7 +377,7 @@ TEST(TestExponents, PositiveExponentOfNegativeNumberNumberCannotBeConvertedToWho
 }
 
 TEST(TestExponents, NegativeExponentNumberCannotBeConvertedToWholeNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.00001e-24,
   "b" : 10.00001000000000000001e-18
@@ -400,7 +400,7 @@ TEST(TestExponents, NegativeExponentNumberCannotBeConvertedToWholeNumber) {
 }
 
 TEST(TestExponents, NegativeExponentNumberShiftsEnoughToBecomeANumberAgain) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 1.00001e-24
 }
@@ -418,7 +418,7 @@ TEST(TestExponents, NegativeExponentNumberShiftsEnoughToBecomeANumberAgain) {
 }
 
 TEST(TestExponents, NegativeExponentNumberWithZeroWholeNumberShiftsEnoughToBecomeANumberAgain) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.00003000000000000002e-18
 }
@@ -436,7 +436,7 @@ TEST(TestExponents, NegativeExponentNumberWithZeroWholeNumberShiftsEnoughToBecom
 }
 
 TEST(TestExponents, FractionShiftExactlyToTheLeft) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.123e3
 }
@@ -454,7 +454,7 @@ TEST(TestExponents, FractionShiftExactlyToTheLeft) {
 }
 
 TEST(TestExponents, FractionShiftToTheLeftLessThanTheNumberOfFractions) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.123e2
 }
@@ -472,7 +472,7 @@ TEST(TestExponents, FractionShiftToTheLeftLessThanTheNumberOfFractions) {
 }
 
 TEST(TestExponents, FractionShiftToTheLeftLessThanTheNumberOfFractionsButHasNoLeadingZeros) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.123e2
 }
@@ -490,7 +490,7 @@ TEST(TestExponents, FractionShiftToTheLeftLessThanTheNumberOfFractionsButHasNoLe
 }
 
 TEST(TestExponents, FractionShiftToTheLeftLessThanTheTotalNumberOfFractionsButHasLeadingZeros) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.0012e2,
   "b" : 0.00012e3,
@@ -518,7 +518,7 @@ TEST(TestExponents, FractionShiftToTheLeftLessThanTheTotalNumberOfFractionsButHa
 }
 
 TEST(TestExponents, FractionShiftToTheLeftLessThanTheNumberOfFractionsButHasLeadingZeros) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0.0123e3
 }

--- a/tests/testtinyjsonexponents.cpp
+++ b/tests/testtinyjsonexponents.cpp
@@ -251,19 +251,19 @@ TEST(TestExponents, LargeExponentIsConvertedToSingleWholeNumber) {
 
   auto valuea = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("a"));
   ASSERT_NE(nullptr, valuea);
-  EXPECT_STREQ("1.23045e+27", valuea->dump(TinyJSON::formating::none));
+  EXPECT_STREQ("1.23045e+27", valuea->dump(TinyJSON::formating::minify));
 
   auto valueb = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("b"));
   ASSERT_NE(nullptr, valueb);
-  EXPECT_STREQ("6.7809e+27", valueb->dump(TinyJSON::formating::none));
+  EXPECT_STREQ("6.7809e+27", valueb->dump(TinyJSON::formating::minify));
 
   auto valuec = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("c"));
   ASSERT_NE(nullptr, valuec);
-  EXPECT_STREQ("1.0009e+27", valuec->dump(TinyJSON::formating::none));
+  EXPECT_STREQ("1.0009e+27", valuec->dump(TinyJSON::formating::minify));
 
   auto valued = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("d"));
   ASSERT_NE(nullptr, valued);
-  EXPECT_STREQ("1.2345e+27", valued->dump(TinyJSON::formating::none));
+  EXPECT_STREQ("1.2345e+27", valued->dump(TinyJSON::formating::minify));
 
   delete json;
 }
@@ -353,7 +353,7 @@ TEST(TestExponents, PositiveExponentNumberCannotBeConvertedToWholeNumber) {
 
   auto valuea = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("a"));
   ASSERT_NE(nullptr, valuea);
-  ASSERT_STREQ("2.00001e+24", valuea->dump(TinyJSON::formating::none));
+  ASSERT_STREQ("2.00001e+24", valuea->dump(TinyJSON::formating::minify));
 
   delete json;
 }
@@ -371,7 +371,7 @@ TEST(TestExponents, PositiveExponentOfNegativeNumberNumberCannotBeConvertedToWho
 
   auto valuea = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("a"));
   ASSERT_NE(nullptr, valuea);
-  ASSERT_STREQ("-2.00001e+24", valuea->dump(TinyJSON::formating::none));
+  ASSERT_STREQ("-2.00001e+24", valuea->dump(TinyJSON::formating::minify));
 
   delete json;
 }
@@ -390,11 +390,11 @@ TEST(TestExponents, NegativeExponentNumberCannotBeConvertedToWholeNumber) {
 
   auto valuea = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("a"));
   ASSERT_NE(nullptr, valuea);
-  ASSERT_STREQ("1.200001e-23", valuea->dump(TinyJSON::formating::none));
+  ASSERT_STREQ("1.200001e-23", valuea->dump(TinyJSON::formating::minify));
 
   auto valueb = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("b"));
   ASSERT_NE(nullptr, valueb);
-  ASSERT_STREQ("1.000001000000000000001e-17", valueb->dump(TinyJSON::formating::none));
+  ASSERT_STREQ("1.000001000000000000001e-17", valueb->dump(TinyJSON::formating::minify));
 
   delete json;
 }
@@ -412,7 +412,7 @@ TEST(TestExponents, NegativeExponentNumberShiftsEnoughToBecomeANumberAgain) {
 
   auto valuea = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("a"));
   ASSERT_NE(nullptr, valuea);
-  ASSERT_STREQ("1.00001e-24", valuea->dump(TinyJSON::formating::none));
+  ASSERT_STREQ("1.00001e-24", valuea->dump(TinyJSON::formating::minify));
 
   delete json;
 }
@@ -430,7 +430,7 @@ TEST(TestExponents, NegativeExponentNumberWithZeroWholeNumberShiftsEnoughToBecom
 
   auto valuea = dynamic_cast<const TinyJSON::TJValueNumberExponent*>(jobject->try_get_value("a"));
   ASSERT_NE(nullptr, valuea);
-  ASSERT_STREQ("3.000000000000002e-23", valuea->dump(TinyJSON::formating::none));
+  ASSERT_STREQ("3.000000000000002e-23", valuea->dump(TinyJSON::formating::minify));
 
   delete json;
 }

--- a/tests/testtinyjsonnulls.cpp
+++ b/tests/testtinyjsonnulls.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestNulls, NullIsAfterMissingColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" null
     }
@@ -16,7 +16,7 @@ TEST(TestNulls, NullIsAfterMissingColon) {
 }
 
 TEST(TestNulls, CheckForNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : null
 }
@@ -36,7 +36,7 @@ TEST(TestNulls, CheckForNull) {
 }
 
 TEST(TestNulls, CheckForNullInsideAnArray) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   null, null
 ]
@@ -56,7 +56,7 @@ TEST(TestNulls, CheckForNullInsideAnArray) {
 }
 
 TEST(TestNulls, NullNotSpelledProperly1) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : n
     }
@@ -66,7 +66,7 @@ TEST(TestNulls, NullNotSpelledProperly1) {
 }
 
 TEST(TestNulls, NullNotSpelledProperly2) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : nu
     }
@@ -76,7 +76,7 @@ TEST(TestNulls, NullNotSpelledProperly2) {
 }
 
 TEST(TestNulls, NullNotSpelledProperly3) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : nul
     }
@@ -86,7 +86,7 @@ TEST(TestNulls, NullNotSpelledProperly3) {
 }
 
 TEST(TestNulls, NullWordIsNotNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : "null"
 }
@@ -109,7 +109,7 @@ TEST(TestNulls, NullWordIsNotNull) {
 }
 
 TEST(TestNulls, CheckThatValueIsNullValue) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : null
     }
@@ -135,7 +135,7 @@ TEST(TestNulls, CheckThatValueIsNullValue) {
 }
 
 TEST(TestNulls, CheckThatValueIsNullValueInArray) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     [
       null
     ]

--- a/tests/testtinyjsonnumbers.cpp
+++ b/tests/testtinyjsonnumbers.cpp
@@ -7,7 +7,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestNumbers, NumberIsAfterMissingColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" 42
     }
@@ -17,7 +17,7 @@ TEST(TestNumbers, NumberIsAfterMissingColon) {
 }
 
 TEST(TestNumbers, WholeNumbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12,
   "b" : -42,
@@ -46,7 +46,7 @@ TEST(TestNumbers, WholeNumbers) {
 }
 
 TEST(TestNumbers, FractionsWithLeadingZeros) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 1.0001,
   "b" : 0.00002
@@ -69,7 +69,7 @@ TEST(TestNumbers, FractionsWithLeadingZeros) {
 }
 
 TEST(TestNumbers, WholeNumbersWithZeroDecimals) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.10000,
   "b" : -42.000,
@@ -98,7 +98,7 @@ TEST(TestNumbers, WholeNumbersWithZeroDecimals) {
 }
 
 TEST(TestNumbers, WholeNumbersIsZero) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0,
   "b" : -0,
@@ -127,7 +127,7 @@ TEST(TestNumbers, WholeNumbersIsZero) {
 }
 
 TEST(TestNumbers, FractionNUmbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.1,
   "b" : -42.6,
@@ -160,7 +160,7 @@ TEST(TestNumbers, FractionNUmbers) {
 }
 
 TEST(TestNumbers, MaxPositiveNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 9223372036854775807,
   "b" : -9223372036854775806
@@ -183,7 +183,7 @@ TEST(TestNumbers, MaxPositiveNumber) {
 }
 
 TEST(TestNumbers, InvalidWholeNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12.
 }
@@ -199,7 +199,7 @@ TEST(TestNumbers, TestManyWholeNumbers) {
     std::string value = std::to_string(s);
 
     std::string s_json = "{ \"a\" :" + value + "}";
-    auto json = TinyJSON::TinyJSON::parse(s_json.c_str());
+    auto json = TinyJSON::TJ::parse(s_json.c_str());
 
     ASSERT_NE(nullptr, json);
     auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
@@ -237,7 +237,7 @@ TEST(TestNumbers, TestManyFloatNumbers) {
   for (auto value : values)
   {
     std::string s_json = "{ \"a\" : " + value.given + "}";
-    auto json = TinyJSON::TinyJSON::parse(s_json.c_str());
+    auto json = TinyJSON::TJ::parse(s_json.c_str());
 
     ASSERT_NE(nullptr, json);
     auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
@@ -275,7 +275,7 @@ TEST(TestNumbers, TestManyComplexFloatNumbers) {
   for (auto value : values)
   {
     std::string s_json = "{ \"a\" : " + value.given + "}";
-    auto json = TinyJSON::TinyJSON::parse(s_json.c_str());
+    auto json = TinyJSON::TJ::parse(s_json.c_str());
 
     ASSERT_NE(nullptr, json);
     auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
@@ -291,7 +291,7 @@ TEST(TestNumbers, TestManyComplexFloatNumbers) {
 }
 
 TEST(TestNumbers, CheckThatValueIsNumber) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 123
 }
@@ -316,7 +316,7 @@ TEST(TestNumbers, CheckThatValueIsNumber) {
 }
 
 TEST(TestNumbers, CheckThatValueIsNumberInArray) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   42
 ]
@@ -342,7 +342,7 @@ TEST(TestNumbers, CheckThatValueIsNumberInArray) {
 }
 
 TEST(TestNumbers, InvalidWholeNumber2) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12as
 }
@@ -352,7 +352,7 @@ TEST(TestNumbers, InvalidWholeNumber2) {
 }
 
 TEST(TestNumbers, UnexpectedSpaceInTheNumbers) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   12,14,1 5
 ]
@@ -378,7 +378,7 @@ TEST(TestBooleans, CloneInt) {
 }
 
 TEST(TestNumbers, NumberCannotHaveALeadingZero) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0123
 }
@@ -388,7 +388,7 @@ TEST(TestNumbers, NumberCannotHaveALeadingZero) {
 }
 
 TEST(TestNumbers, NegativeNumberCannotHaveALeadingZero) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : -0123
 }
@@ -398,7 +398,7 @@ TEST(TestNumbers, NegativeNumberCannotHaveALeadingZero) {
 }
 
 TEST(TestNumbers, NumberCannotHaveALeadingZeroEvenIfDecimal) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 0123.45
 }
@@ -408,7 +408,7 @@ TEST(TestNumbers, NumberCannotHaveALeadingZeroEvenIfDecimal) {
 }
 
 TEST(TestNumbers, JustZero) {
-  auto json = TinyJSON::TinyJSON::parse( "0");
+  auto json = TinyJSON::TJ::parse( "0");
 
   ASSERT_NE(nullptr, json);
   auto value = dynamic_cast<const TinyJSON::TJValueNumberInt*>(json);
@@ -419,7 +419,7 @@ TEST(TestNumbers, JustZero) {
 }
 
 TEST(TestNumbers, JustZeroDecimal) {
-  auto json = TinyJSON::TinyJSON::parse("0.0");
+  auto json = TinyJSON::TJ::parse("0.0");
 
   ASSERT_NE(nullptr, json);
   auto value = dynamic_cast<const TinyJSON::TJValueNumberInt*>(json);

--- a/tests/testtinyjsonobjects.cpp
+++ b/tests/testtinyjsonobjects.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestObjects, MakeSureThatEmptyStringIsKinkOfValueObject) {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
   ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValue*>(json));
   ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValueObject*>(json));
@@ -15,7 +15,7 @@ TEST(TestObjects, MakeSureThatEmptyStringIsKinkOfValueObject) {
 }
 
 TEST(TestObjects, EmptyObjectHasNoItemsInIt) {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
   ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValue*>(json));
 
@@ -27,7 +27,7 @@ TEST(TestObjects, EmptyObjectHasNoItemsInIt) {
 }
 
 TEST(TestObjects, EmptyObjectInSideObectHasNoItemsInIt) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : {
       }
@@ -50,7 +50,7 @@ TEST(TestObjects, EmptyObjectInSideObectHasNoItemsInIt) {
 }
 
 TEST(TestObjects, GetItemByIndex) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" : {
         "aa" : {}
@@ -78,12 +78,12 @@ TEST(TestObjects, GetItemByIndex) {
 }
 
 TEST(TestObjects, ClosedObjectTwice) {
-  auto json = TinyJSON::TinyJSON::parse("{}}");
+  auto json = TinyJSON::TJ::parse("{}}");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestObjects, ObjectIsAfterMissingColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" {
         "b" : 12
@@ -95,19 +95,19 @@ TEST(TestObjects, ObjectIsAfterMissingColon) {
 }
 
 TEST(TestObjects, ObjectOpensButNeverCloses) {
-  auto json = TinyJSON::TinyJSON::parse("{");
+  auto json = TinyJSON::TJ::parse("{");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestObjects, ObjectOpensAndHasValuesButNeverCloses) {
-  auto json = TinyJSON::TinyJSON::parse(R"({
+  auto json = TinyJSON::TJ::parse(R"({
     "a" : "b"
     )");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestObjects, CheckThatValueIsObject) {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
 
   ASSERT_TRUE(json->is_object());
@@ -121,7 +121,7 @@ TEST(TestObjects, CheckThatValueIsObject) {
 }
 
 TEST(TestObjects, TryingToGetAnItemThatDoesNotExitReturnsNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12, "b" : 13, "c" : 14
 }
@@ -137,7 +137,7 @@ TEST(TestObjects, TryingToGetAnItemThatDoesNotExitReturnsNull) {
 }
 
 TEST(TestObjects, TryingToGetANegativeItemReturnsNull) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12, "b" : 13, "c" : 14
 }
@@ -154,7 +154,7 @@ TEST(TestObjects, TryingToGetANegativeItemReturnsNull) {
 }
 
 TEST(TestObjects, ObjectHasAValidStringJustNoColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" 
     }
@@ -164,7 +164,7 @@ TEST(TestObjects, ObjectHasAValidStringJustNoColon) {
 }
 
 TEST(TestObjects, ItemsInArrayMustBeSeparatedByComma) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12
   "b" : 13
@@ -175,7 +175,7 @@ TEST(TestObjects, ItemsInArrayMustBeSeparatedByComma) {
 }
 
 TEST(TestObjects, ItemsInArrayMustBeSeparatedByCommaWithStrings) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : "A"
   "b" : "B"
@@ -186,7 +186,7 @@ TEST(TestObjects, ItemsInArrayMustBeSeparatedByCommaWithStrings) {
 }
 
 TEST(TestObjects, ItemsInArrayMustBeSeparatedByCommaWithNumberAndStrings) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a" : 12
   "b" : "B"
@@ -197,7 +197,7 @@ TEST(TestObjects, ItemsInArrayMustBeSeparatedByCommaWithNumberAndStrings) {
 }
 
 TEST(TestObjects, ObjectHasACommaButThenTheObjectEnds) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "a" : 12,
   "b" : "B",
@@ -208,7 +208,7 @@ TEST(TestObjects, ObjectHasACommaButThenTheObjectEnds) {
 }
 
 TEST(TestObjects, TheLastItemInOurBrokenJsonIsAnEscape) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
  "a" : "test1"
  "b" : "tes2\)"

--- a/tests/testtinyjsonstrings.cpp
+++ b/tests/testtinyjsonstrings.cpp
@@ -6,7 +6,7 @@
 #include "../src/TinyJSON.h"
 
 TEST(TestStrings, StringIsAfterMissingColon) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     {
       "a" "b"
     }
@@ -16,7 +16,7 @@ TEST(TestStrings, StringIsAfterMissingColon) {
 }
 
 TEST(TestStrings, TheStringNameValueIsSaved) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" : "World"
 }
@@ -33,7 +33,7 @@ TEST(TestStrings, TheStringNameValueIsSaved) {
 }
 
 TEST(TestStrings, TheStringNameValueIsSavedMultiLine) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" 
     : 
@@ -51,7 +51,7 @@ TEST(TestStrings, TheStringNameValueIsSavedMultiLine) {
 }
 
 TEST(TestStrings, TheStringNameValueIsSavedNultiplItems) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "a name" : "a value",
   "b name" : "b value",
@@ -71,7 +71,7 @@ TEST(TestStrings, TheStringNameValueIsSavedNultiplItems) {
 }
 
 TEST(TestStrings, ArrayOfString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "Hello" , "World"
 ]
@@ -90,7 +90,7 @@ TEST(TestStrings, ArrayOfString) {
 }
 
 TEST(TestStrings, CheckThatValueWithAVeryLongKeyValuePair) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "ThisIsALongStringThatIsNormallyLongerThanTheDefault" : "The longest word is Pneumonoultramicroscopicsilicovolcanoconiosis"
 }
@@ -110,7 +110,7 @@ TEST(TestStrings, CheckThatValueWithAVeryLongKeyValuePair) {
 }
 
 TEST(TestStrings, CheckThatValueIsString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" : "World"
 }
@@ -136,7 +136,7 @@ TEST(TestStrings, CheckThatValueIsString) {
 }
 
 TEST(TestStrings, CheckThatValueIsStringInArray) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "Hello", "World"
 ]
@@ -162,7 +162,7 @@ TEST(TestStrings, CheckThatValueIsStringInArray) {
 }
 
 TEST(TestStrings, DifferentEscapeTypes) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "\\\"Hello\\\"",
   "\/\"Hello\/\""
@@ -181,7 +181,7 @@ TEST(TestStrings, DifferentEscapeTypes) {
 }
 
 TEST(TestStrings, EscapeQuoteInString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "\\\"Escape Then quote\\\"",
   "\"Quote\""
@@ -200,7 +200,7 @@ TEST(TestStrings, EscapeQuoteInString) {
 }
 
 TEST(TestStrings, EscapeFormFeedInString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "This is a \fA Form feed"
 ]
@@ -217,7 +217,7 @@ TEST(TestStrings, EscapeFormFeedInString) {
 }
 
 TEST(TestStrings, EscapeBackSpaceInString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "This is a \bA backspace"
 ]
@@ -234,7 +234,7 @@ TEST(TestStrings, EscapeBackSpaceInString) {
 }
 
 TEST(TestStrings, EscapeNewLineInString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "This is a \nNew Line"
 ]
@@ -251,7 +251,7 @@ TEST(TestStrings, EscapeNewLineInString) {
 }
 
 TEST(TestStrings, EscapeCarriageReturnInString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "This is a \rCarriage return"
 ]
@@ -268,7 +268,7 @@ TEST(TestStrings, EscapeCarriageReturnInString) {
 }
 
 TEST(TestStrings, EscapeTabInString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "This is a \tTab"
 ]
@@ -285,7 +285,7 @@ TEST(TestStrings, EscapeTabInString) {
 }
 
 TEST(TestStrings, EscapeQuoteInStringKeyValuePair) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "\\\"Hello\\\"" : "\"World\""
 }
@@ -302,7 +302,7 @@ TEST(TestStrings, EscapeQuoteInStringKeyValuePair) {
 }
 
 TEST(TestStrings, TheLastItemInOurBrokenJsonIsAnEscape) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
 "test1"
 "tes2\)"
@@ -312,7 +312,7 @@ TEST(TestStrings, TheLastItemInOurBrokenJsonIsAnEscape) {
 }
 
 TEST(TestStrings, ADumpedStringWithAReverseSolidusKeepsReverseSolidus) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\\And this is after a reverse solidus")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\\And this is after a reverse solidus")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -323,7 +323,7 @@ TEST(TestStrings, ADumpedStringWithAReverseSolidusKeepsReverseSolidus) {
 }
 
 TEST(TestStrings, ADumpedStringWithABackSpaceKeepsTheBackSpace) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\bAnd this is after a backspace")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\bAnd this is after a backspace")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -334,7 +334,7 @@ TEST(TestStrings, ADumpedStringWithABackSpaceKeepsTheBackSpace) {
 }
 
 TEST(TestStrings, ADumpedStringWithAFormFeedKeepsTheFormFeed) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\fAnd this is after a form feed")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\fAnd this is after a form feed")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -345,7 +345,7 @@ TEST(TestStrings, ADumpedStringWithAFormFeedKeepsTheFormFeed) {
 }
 
 TEST(TestStrings, ADumpedStringWithANewLineKeepsTheNewLine) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\nAnd this is a new line")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\nAnd this is a new line")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -356,7 +356,7 @@ TEST(TestStrings, ADumpedStringWithANewLineKeepsTheNewLine) {
 }
 
 TEST(TestStrings, ADumpedStringWithACarriageReturnKeepsTheCarriageReturn) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\rAnd this is after a carriage return")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\rAnd this is after a carriage return")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -367,7 +367,7 @@ TEST(TestStrings, ADumpedStringWithACarriageReturnKeepsTheCarriageReturn) {
 }
 
 TEST(TestStrings, ADumpedStringWithATabKeepsTheTab) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\tAnd this is after a tab")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\tAnd this is after a tab")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -378,7 +378,7 @@ TEST(TestStrings, ADumpedStringWithATabKeepsTheTab) {
 }
 
 TEST(TestStrings, ItemInAnObjectHasALineFeed) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" : "Line 1\nLine2"
 }
@@ -395,7 +395,7 @@ TEST(TestStrings, ItemInAnObjectHasALineFeed) {
 }
 
 TEST(TestStrings, ItemInAnObjectHasAFormFeed) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" : "Item 1\fItem2"
 }
@@ -412,7 +412,7 @@ TEST(TestStrings, ItemInAnObjectHasAFormFeed) {
 }
 
 TEST(TestStrings, ItemInAnObjectHasACarriageReturnAndLineFeed) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 {
   "Hello" : "Item 1\r\nItem2"
 }
@@ -429,7 +429,7 @@ TEST(TestStrings, ItemInAnObjectHasACarriageReturnAndLineFeed) {
 }
 
 TEST(TestStrings, ADumpedWithAReverseSolidusKeepsReverseSolidus) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\\And this is after a reverse solidus")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\\And this is after a reverse solidus")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -440,7 +440,7 @@ TEST(TestStrings, ADumpedWithAReverseSolidusKeepsReverseSolidus) {
 }
 
 TEST(TestStrings, ADumpedWithABackSpaceKeepsTheBackSpace) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\bAnd this is after a backspace")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\bAnd this is after a backspace")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -451,7 +451,7 @@ TEST(TestStrings, ADumpedWithABackSpaceKeepsTheBackSpace) {
 }
 
 TEST(TestStrings, ADumpedWithAFormFeedKeepsTheFormFeed) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\fAnd this is after a form feed")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\fAnd this is after a form feed")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -462,7 +462,7 @@ TEST(TestStrings, ADumpedWithAFormFeedKeepsTheFormFeed) {
 }
 
 TEST(TestStrings, ADumpedWithANewLineKeepsTheNewLine) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\nAnd this is a new line")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\nAnd this is a new line")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -473,7 +473,7 @@ TEST(TestStrings, ADumpedWithANewLineKeepsTheNewLine) {
 }
 
 TEST(TestStrings, ADumpedWithACarriageReturnKeepsTheCarriageReturn) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\rAnd this is after a carriage return")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\rAnd this is after a carriage return")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -484,7 +484,7 @@ TEST(TestStrings, ADumpedWithACarriageReturnKeepsTheCarriageReturn) {
 }
 
 TEST(TestStrings, ADumpedWithATabKeepsTheTab) {
-  auto json = TinyJSON::TinyJSON::parse(R"("This is a string.\tAnd this is after a tab")");
+  auto json = TinyJSON::TJ::parse(R"("This is a string.\tAnd this is after a tab")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump(TinyJSON::formating::none);
@@ -495,7 +495,7 @@ TEST(TestStrings, ADumpedWithATabKeepsTheTab) {
 }
 
 TEST(TestStrings, YouCannotHaveALineFeedInAString) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
     [
       "This is
 Invalid"])"
@@ -504,22 +504,22 @@ Invalid"])"
 }
 
 TEST(TestStrings, YouCannotHaveAFormFeedInAString) {
-  auto json = TinyJSON::TinyJSON::parse("[   \"This is \fInvalid\"]   ");
+  auto json = TinyJSON::TJ::parse("[   \"This is \fInvalid\"]   ");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestStrings, YouCannotHaveASingleReverseSolidusInAString) {
-  auto json = TinyJSON::TinyJSON::parse("[\"This\\ is invalid\"]");
+  auto json = TinyJSON::TJ::parse("[\"This\\ is invalid\"]");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestStrings, YouCannotHaveATabInAString) {
-  auto json = TinyJSON::TinyJSON::parse("[   \"This is \\\tInvalid\"]   ");
+  auto json = TinyJSON::TJ::parse("[   \"This is \\\tInvalid\"]   ");
   ASSERT_EQ(nullptr, json);
 }
 
 TEST(TestStrings, YouCanHaveATabBeforeAndAfterAString) {
-  auto json = TinyJSON::TinyJSON::parse("\t\"This is valid\"\t");
+  auto json = TinyJSON::TJ::parse("\t\"This is valid\"\t");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -531,7 +531,7 @@ TEST(TestStrings, YouCanHaveATabBeforeAndAfterAString) {
 }
 
 TEST(TestStrings, JustControls) {
-  auto json = TinyJSON::TinyJSON::parse(R"("\b\f\n\r\t")");
+  auto json = TinyJSON::TJ::parse(R"("\b\f\n\r\t")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -543,7 +543,7 @@ TEST(TestStrings, JustControls) {
 }
 
 TEST(TestStrings, JustControlsInObject) {
-  auto json = TinyJSON::TinyJSON::parse(R"({"controls": "\b\f\n\r\t"})");
+  auto json = TinyJSON::TJ::parse(R"({"controls": "\b\f\n\r\t"})");
   ASSERT_NE(nullptr, json);
 
   auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
@@ -561,7 +561,7 @@ TEST(TestStrings, JustControlsInObject) {
 }
 
 TEST(TestStrings, JustSlash) {
-  auto json = TinyJSON::TinyJSON::parse(R"("/ & \/")");
+  auto json = TinyJSON::TJ::parse(R"("/ & \/")");
   ASSERT_NE(nullptr, json);
 
   const auto& text = json->dump_string();
@@ -573,7 +573,7 @@ TEST(TestStrings, JustSlash) {
 }
 
 TEST(TestStrings, JustSlashInObject) {
-  auto json = TinyJSON::TinyJSON::parse(R"({"slash": "/ & \/"})");
+  auto json = TinyJSON::TJ::parse(R"({"slash": "/ & \/"})");
   ASSERT_NE(nullptr, json);
 
   auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
@@ -591,7 +591,7 @@ TEST(TestStrings, JustSlashInObject) {
 }
 
 TEST(TestStrings, YouCanHaveATabBeforeAndAfterAStringInObject) {
-  auto json = TinyJSON::TinyJSON::parse("{\"a\" : \t\"This is valid\"\t}");
+  auto json = TinyJSON::TJ::parse("{\"a\" : \t\"This is valid\"\t}");
   ASSERT_NE(nullptr, json);
 
   auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
@@ -604,7 +604,7 @@ TEST(TestStrings, YouCanHaveATabBeforeAndAfterAStringInObject) {
 }
 
 TEST(TestStrings, ValidHexValues) {
-  auto json = TinyJSON::TinyJSON::parse(R"(
+  auto json = TinyJSON::TJ::parse(R"(
 [
   "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A"
 ]

--- a/tests/testtinyjsonstrings.cpp
+++ b/tests/testtinyjsonstrings.cpp
@@ -432,7 +432,7 @@ TEST(TestStrings, ADumpedWithAReverseSolidusKeepsReverseSolidus) {
   auto json = TinyJSON::TJ::parse(R"("This is a string.\\And this is after a reverse solidus")");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"("This is a string.\\And this is after a reverse solidus")", text);
@@ -443,7 +443,7 @@ TEST(TestStrings, ADumpedWithABackSpaceKeepsTheBackSpace) {
   auto json = TinyJSON::TJ::parse(R"("This is a string.\bAnd this is after a backspace")");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"("This is a string.\bAnd this is after a backspace")", text);
@@ -454,7 +454,7 @@ TEST(TestStrings, ADumpedWithAFormFeedKeepsTheFormFeed) {
   auto json = TinyJSON::TJ::parse(R"("This is a string.\fAnd this is after a form feed")");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"("This is a string.\fAnd this is after a form feed")", text);
@@ -465,7 +465,7 @@ TEST(TestStrings, ADumpedWithANewLineKeepsTheNewLine) {
   auto json = TinyJSON::TJ::parse(R"("This is a string.\nAnd this is a new line")");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"("This is a string.\nAnd this is a new line")", text);
@@ -476,7 +476,7 @@ TEST(TestStrings, ADumpedWithACarriageReturnKeepsTheCarriageReturn) {
   auto json = TinyJSON::TJ::parse(R"("This is a string.\rAnd this is after a carriage return")");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"("This is a string.\rAnd this is after a carriage return")", text);
@@ -487,7 +487,7 @@ TEST(TestStrings, ADumpedWithATabKeepsTheTab) {
   auto json = TinyJSON::TJ::parse(R"("This is a string.\tAnd this is after a tab")");
   ASSERT_NE(nullptr, json);
 
-  const auto& text = json->dump(TinyJSON::formating::none);
+  const auto& text = json->dump(TinyJSON::formating::minify);
   ASSERT_NE(nullptr, text);
 
   ASSERT_STREQ(R"("This is a string.\tAnd this is after a tab")", text);

--- a/tests/testtinyjsonwrite.cpp
+++ b/tests/testtinyjsonwrite.cpp
@@ -59,36 +59,36 @@ protected:
 
 TEST_F(TestWrite, FileIsCreated) 
 {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json));
   ASSERT_TRUE(file_exists(filename));
   delete json;
 }
 
 TEST_F(TestWrite, EmptyObject)
 {
-  auto json = TinyJSON::TinyJSON::parse("{}");
+  auto json = TinyJSON::TJ::parse("{}");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json));
   ASSERT_STREQ("{}", read_fileContent(filename).c_str());
   delete json;
 }
 
 TEST_F(TestWrite, EmptyArray)
 {
-  auto json = TinyJSON::TinyJSON::parse("[]");
+  auto json = TinyJSON::TJ::parse("[]");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json));
   ASSERT_STREQ("[]", read_fileContent(filename).c_str());
   delete json;
 }
 
 TEST_F(TestWrite, ArrayWithValuesIsIndented)
 {
-  auto json = TinyJSON::TinyJSON::parse("[1,2,3,4]");
+  auto json = TinyJSON::TJ::parse("[1,2,3,4]");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json));
   ASSERT_STREQ(R"([
   1,
   2,
@@ -102,9 +102,9 @@ TEST_F(TestWrite, ArrayWithValuesNotIndented)
 {
   TinyJSON::write_options options = {};
   options.write_formating = TinyJSON::formating::none;
-  auto json = TinyJSON::TinyJSON::parse("[1,2,3,4]");
+  auto json = TinyJSON::TJ::parse("[1,2,3,4]");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json, options));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json, options));
   ASSERT_STREQ(R"([1,2,3,4])", read_fileContent(filename).c_str());
   delete json;
 }
@@ -114,9 +114,9 @@ TEST_F(TestWrite, ArrayWithValuesNotIndentedWithUtf8Bom)
   TinyJSON::write_options options = {};
   options.write_formating = TinyJSON::formating::none;
   options.byte_order_mark = TinyJSON::write_options::utf8;
-  auto json = TinyJSON::TinyJSON::parse("[1,2,3,4]");
+  auto json = TinyJSON::TJ::parse("[1,2,3,4]");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json, options));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json, options));
 
   // make sure we have the BOM
   ASSERT_TRUE(has_Utf8BOM(filename));
@@ -124,7 +124,7 @@ TEST_F(TestWrite, ArrayWithValuesNotIndentedWithUtf8Bom)
   // then try and parse it again.
   TinyJSON::parse_options options_parse = {};
   options_parse.throw_exception = true;
-  auto parse = TinyJSON::TinyJSON::parse_file(filename, options_parse);
+  auto parse = TinyJSON::TJ::parse_file(filename, options_parse);
   ASSERT_NE(nullptr, parse);
   ASSERT_STREQ(R"([1,2,3,4])", parse->dump(TinyJSON::formating::none));
   delete json;
@@ -136,9 +136,9 @@ TEST_F(TestWrite, ObjectWithValuesNotIndentedWithUtf8Bom)
   TinyJSON::write_options options = {};
   options.write_formating = TinyJSON::formating::none;
   options.byte_order_mark = TinyJSON::write_options::utf8;
-  auto json = TinyJSON::TinyJSON::parse(R"({"a":12, "b" : {}})");
+  auto json = TinyJSON::TJ::parse(R"({"a":12, "b" : {}})");
   ASSERT_NE(nullptr, json);
-  ASSERT_TRUE(TinyJSON::TinyJSON::write_file(filename, *json, options));
+  ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json, options));
 
   // make sure we have the BOM
   ASSERT_TRUE(has_Utf8BOM(filename));
@@ -146,7 +146,7 @@ TEST_F(TestWrite, ObjectWithValuesNotIndentedWithUtf8Bom)
   // then try and parse it again.
   TinyJSON::parse_options options_parse = {};
   options_parse.throw_exception = true;
-  auto parse = TinyJSON::TinyJSON::parse_file(filename, options_parse);
+  auto parse = TinyJSON::TJ::parse_file(filename, options_parse);
   ASSERT_NE(nullptr, parse);
   ASSERT_STREQ(R"({"a":12,"b":{}})", parse->dump(TinyJSON::formating::none));
   delete json;

--- a/tests/testtinyjsonwrite.cpp
+++ b/tests/testtinyjsonwrite.cpp
@@ -101,7 +101,7 @@ TEST_F(TestWrite, ArrayWithValuesIsIndented)
 TEST_F(TestWrite, ArrayWithValuesNotIndented)
 {
   TinyJSON::write_options options = {};
-  options.write_formating = TinyJSON::formating::none;
+  options.write_formating = TinyJSON::formating::minify;
   auto json = TinyJSON::TJ::parse("[1,2,3,4]");
   ASSERT_NE(nullptr, json);
   ASSERT_TRUE(TinyJSON::TJ::write_file(filename, *json, options));
@@ -112,7 +112,7 @@ TEST_F(TestWrite, ArrayWithValuesNotIndented)
 TEST_F(TestWrite, ArrayWithValuesNotIndentedWithUtf8Bom)
 {
   TinyJSON::write_options options = {};
-  options.write_formating = TinyJSON::formating::none;
+  options.write_formating = TinyJSON::formating::minify;
   options.byte_order_mark = TinyJSON::write_options::utf8;
   auto json = TinyJSON::TJ::parse("[1,2,3,4]");
   ASSERT_NE(nullptr, json);
@@ -126,7 +126,7 @@ TEST_F(TestWrite, ArrayWithValuesNotIndentedWithUtf8Bom)
   options_parse.throw_exception = true;
   auto parse = TinyJSON::TJ::parse_file(filename, options_parse);
   ASSERT_NE(nullptr, parse);
-  ASSERT_STREQ(R"([1,2,3,4])", parse->dump(TinyJSON::formating::none));
+  ASSERT_STREQ(R"([1,2,3,4])", parse->dump(TinyJSON::formating::minify));
   delete json;
   delete parse;
 }
@@ -134,7 +134,7 @@ TEST_F(TestWrite, ArrayWithValuesNotIndentedWithUtf8Bom)
 TEST_F(TestWrite, ObjectWithValuesNotIndentedWithUtf8Bom)
 {
   TinyJSON::write_options options = {};
-  options.write_formating = TinyJSON::formating::none;
+  options.write_formating = TinyJSON::formating::minify;
   options.byte_order_mark = TinyJSON::write_options::utf8;
   auto json = TinyJSON::TJ::parse(R"({"a":12, "b" : {}})");
   ASSERT_NE(nullptr, json);
@@ -148,7 +148,7 @@ TEST_F(TestWrite, ObjectWithValuesNotIndentedWithUtf8Bom)
   options_parse.throw_exception = true;
   auto parse = TinyJSON::TJ::parse_file(filename, options_parse);
   ASSERT_NE(nullptr, parse);
-  ASSERT_STREQ(R"({"a":12,"b":{}})", parse->dump(TinyJSON::formating::none));
+  ASSERT_STREQ(R"({"a":12,"b":{}})", parse->dump(TinyJSON::formating::minify));
   delete json;
   delete parse;
 }


### PR DESCRIPTION
Added 3 kinds of string literals.

- `_tj`: get the pointer of the code
- `_tj_indent`: get indented string.
- `_tj_minify`: get minify string.

See the [.\examples\user_literals.cpp](.\examples\user_literals.cpp) code

Fixed /issues/20
