### PR TITLE
We are now able to search by case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,26 @@ std::cout << "[12 , 13 , 14]"_tj_minify;
 ...
 ```
 
+### Search an object by key
+
+There are 2 ways to find a key, case sensitive or insensitive, (the default is case sensitive).
+
+You can load the json either by parsing or creating it manually.
+
+```cpp
+  auto object = new TinyJSON::TJValueObject();
+  object->set("a", "Hello");
+  object->set("b", "World");
+  object->set("c", "Bye");
+  ...
+  // search for something
+  auto case_sensitive = object->try_get_value("Hello");
+  auto case_insensitive = object->try_get_value("HelLO", false);  // all good as we don't care about case.
+  auto case_insensitive_not_found = object->try_get_value("HelLO");  // = null as the search was case sensitive
+  ...
+  delete object;
+```
+
 ### How to create a JSON value?
 
 ```cpp

--- a/example/basic_parse.cpp
+++ b/example/basic_parse.cpp
@@ -164,20 +164,11 @@ bool object_keys_valid()
   auto tjobject = dynamic_cast<TinyJSON::TJValueObject*>(tjjson);
   auto o1 = dynamic_cast<const TinyJSON::TJValueNumberInt*>(tjobject->try_get_value("a"));
   auto o2 = dynamic_cast<const TinyJSON::TJValueString*>(tjobject->try_get_value("A"));
-#if TJ_KEY_CASE_SENSITIVE == 1  
-  if(o1 != nullptr)
-  {
-    // the value should have been overwriten!
-    std::cout << "Bad!!!\n\n";
-    return false;
-  }
-#else
   if(o1 == nullptr)
   {
     std::cout << "Bad!!!\n\n";
     return false;
   }
-#endif  
 
   if(o2 == nullptr)
   {

--- a/example/basic_parse.cpp
+++ b/example/basic_parse.cpp
@@ -145,6 +145,49 @@ bool object_parse()
   return true;
 }
 
+bool object_keys_valid()
+{
+  std::cout << "Object Keys \n";
+  auto json = R"({
+    "a" : 12,
+    "A" : "Hello world"
+  })";
+
+  if (!TinyJSON::TJ::is_valid(json))
+  {
+    // this should have been valid!
+    std::cout << "Bad!!!\n\n";
+    return false;
+  }
+  auto tjjson = TinyJSON::TJ::parse(json);
+
+  auto tjobject = dynamic_cast<TinyJSON::TJValueObject*>(tjjson);
+  auto o1 = dynamic_cast<const TinyJSON::TJValueNumberInt*>(tjobject->try_get_value("a"));
+  auto o2 = dynamic_cast<const TinyJSON::TJValueString*>(tjobject->try_get_value("A"));
+#if TJ_KEY_CASE_SENSITIVE == 1  
+  if(o1 != nullptr)
+  {
+    // the value should have been overwriten!
+    std::cout << "Bad!!!\n\n";
+    return false;
+  }
+#else
+  if(o1 == nullptr)
+  {
+    std::cout << "Bad!!!\n\n";
+    return false;
+  }
+#endif  
+
+  if(o2 == nullptr)
+  {
+    std::cout << "Bad!!!\n\n";
+    return false;
+  }
+  std::cout << "Good\n\n";
+  return true;
+}
+
 bool object_find_values()
 {
   std::cout << "Object Find Value\n";
@@ -214,5 +257,9 @@ int main()
   {
     return -1;
   }
+  if(!object_keys_valid())
+  {
+    return -1;
+  } 
   return 0;
 }

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -805,6 +805,12 @@ namespace TinyJSON
     /// </summary>
     unsigned int _capacity;
 
+    /// <summary>
+    /// Update the value of the key for a given dictionary.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="dictionary_index"></param>
+    /// <param name="dictionary"></param>
     static void replace_dictionary_data
     (
       const TJCHAR* key,
@@ -909,6 +915,12 @@ namespace TinyJSON
       return true;
     }
 
+    /// <summary>
+    /// Remove a dictionary entry at a given index.
+    /// </summary>
+    /// <param name="dictionary_index">The dictionary index.</param>
+    /// <param name="dictionary_size"></param>
+    /// <param name="dictionary">The dictionary we will be looking in</param>
     static void remove_dictionary_data_by_dictionary_index
     (
       const unsigned int& dictionary_index,
@@ -931,6 +943,12 @@ namespace TinyJSON
       );
     }
 
+    /// <summary>
+    /// Remove a dictionary entry given the value index we are looking for.
+    /// </summary>
+    /// <param name="index">The value index we are looking for.</param>
+    /// <param name="dictionary_size"></param>
+    /// <param name="dictionary">The dictionary we will be looking in</param>
     static void remove_dictionary_data_by_value_index(
       const unsigned int& index,
       unsigned int& dictionary_size,
@@ -950,11 +968,25 @@ namespace TinyJSON
         // update the counter
         --dictionary_size;
 
+        // finally we need to move all the index _after_ the dictionary index down by one.
+        uppdate_dictionary_data_by_value_index(
+          value_index,
+          dictionary_size,
+          dictionary
+        );
+
         // we have to get out as we removed them one and only.
         return;
       }
     }
 
+    /// <summary>
+    /// As we removed a value index we need to shift all the value indexes
+    /// That are past the value index.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <param name="dictionary_size"></param>
+    /// <param name="dictionary"></param>
     static void uppdate_dictionary_data_by_value_index(
       const unsigned int& index,
       const unsigned int& dictionary_size,
@@ -1001,6 +1033,12 @@ namespace TinyJSON
       }
     }
 
+    /// <summary>
+    /// Remove a single dictionary entry shift the data.
+    /// </summary>
+    /// <param name="dictionary_index"></param>
+    /// <param name="dictionary"></param>
+    /// <param name="dictionary_size"></param>
     static void remove_dictionary_data(
       unsigned int dictionary_index,
       dictionary_data*& dictionary,
@@ -1072,6 +1110,7 @@ namespace TinyJSON
     /// the key order valid.
     /// </summary>
     /// <param name="key"></param>
+    /// <param name="case_sensitive">If the search is case sensitive or not.</param>
     /// <returns></returns>
     search_result binary_search(const TJCHAR* key, bool case_sensitive) const
     {
@@ -1082,6 +1121,16 @@ namespace TinyJSON
       return binary_search(key, _values_dictionary_ci, _number_of_items_dictionary_ci, false);
     }
 
+    /// <summary>
+    /// Do a binary search and return either the exact location of the item
+    /// or the location of the item we should insert in the dictionary if we want to keep 
+    /// the key order valid.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="dictionary"></param>
+    /// <param name="dictionary_size"></param>
+    /// <param name="case_sensitive"></param>
+    /// <returns></returns>
     static search_result binary_search(
       const TJCHAR* key, 
       const dictionary_data* dictionary,

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -569,14 +569,14 @@ namespace TinyJSON
       // is the one we want to remove
       auto binary_search_result_cs = binary_search(key, true);
       auto dictionary_index_cs = binary_search_result_cs._dictionary_index;
-      int value_index_cs = binary_search_result_cs._was_found ? _values_dictionary_cs[binary_search_result_cs._dictionary_index]._value_index : -1;
+      int value_index_cs = binary_search_result_cs._was_found ? _values_dictionary_cs[dictionary_index_cs]._value_index : -1;
 
       // the case insensitive one is a little more complex.
       // if we have "a" and "A" in our database and we want to pop("a")
       // then we have to make sure that we get the correct one.
       auto binary_search_result_ci = binary_search(key, false);
       auto dictionary_index_ci = binary_search_result_ci._dictionary_index;
-      int value_index_ci = binary_search_result_ci._was_found ? _values_dictionary_cs[binary_search_result_ci._dictionary_index]._value_index : -1;
+      int value_index_ci = binary_search_result_ci._was_found ? _values_dictionary_cs[dictionary_index_ci]._value_index : -1;
 
       // if we have no indexes then we have noting to pop.
       if (value_index_cs == -1)

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -590,11 +590,19 @@ namespace TinyJSON
       if (value_index_cs == value_index_ci)
       {
         /// life is good, we are all pointing at the same code.
-        // so we can remove both values
-        // TBD: we will do another search here ... 
-        //      we need to remove that extra search as we know who is being removed.
-        remove_dictionary_data(key, true);
-        remove_dictionary_data(key, false);
+        // so we can remove both values at the indexes we found aleady.
+        remove_dictionary_data_by_dictionary_index
+        (
+          binary_search_result_cs._dictionary_index,
+          _number_of_items_dictionary_cs,
+          _values_dictionary_cs
+        );
+        remove_dictionary_data_by_dictionary_index
+        (
+          binary_search_result_ci._dictionary_index,
+          _number_of_items_dictionary_ci,
+          _values_dictionary_ci
+        );
       }
       else
       if (value_index_cs != value_index_ci)
@@ -604,7 +612,12 @@ namespace TinyJSON
         // so we now have to remove it by index.
 
         // we know that the case sensitive one was found ... so it can be removed.
-        remove_dictionary_data(key, true);
+        remove_dictionary_data_by_dictionary_index
+        (
+          binary_search_result_cs._dictionary_index,
+          _number_of_items_dictionary_cs,
+          _values_dictionary_cs
+        );
 
         // the issue is the one that is not case sensitive, we nee to remove the correct one.
         remove_dictionary_data_by_value_index(
@@ -878,36 +891,44 @@ namespace TinyJSON
 
       if (case_sensitive == true)
       {
-        auto index = _values_dictionary_cs[binary_search_result._dictionary_index]._value_index;
-        remove_dictionary_data(
+        remove_dictionary_data_by_dictionary_index
+        (
           binary_search_result._dictionary_index,
-          _values_dictionary_cs,
-          _number_of_items_dictionary_cs
-        );
-
-        // finally we need to move all the index _after_ the dictionary index down by one.
-        uppdate_dictionary_data_by_value_index(
-          index,
           _number_of_items_dictionary_cs,
           _values_dictionary_cs
         );
         return true;
       }
 
-      auto index = _values_dictionary_ci[binary_search_result._dictionary_index]._value_index;
-      remove_dictionary_data(
+      remove_dictionary_data_by_dictionary_index
+      (
         binary_search_result._dictionary_index,
-        _values_dictionary_ci,
-        _number_of_items_dictionary_ci
-      );
-
-      uppdate_dictionary_data_by_value_index(
-        index,
         _number_of_items_dictionary_ci,
         _values_dictionary_ci
       );
-
       return true;
+    }
+
+    static void remove_dictionary_data_by_dictionary_index
+    (
+      const unsigned int& dictionary_index,
+      unsigned int& dictionary_size,
+      dictionary_data*& dictionary
+    )
+    {
+      auto index = dictionary[dictionary_index]._value_index;
+      remove_dictionary_data(
+        dictionary_index,
+        dictionary,
+        dictionary_size
+      );
+
+      // finally we need to move all the index _after_ the dictionary index down by one.
+      uppdate_dictionary_data_by_value_index(
+        index,
+        dictionary_size,
+        dictionary
+      );
     }
 
     static void remove_dictionary_data_by_value_index(

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -765,6 +765,7 @@ namespace TinyJSON
       ++_number_of_items_dictionary;
     }
 
+#if TJ_KEY_CASE_SENSITIVE == 1
     /// <summary>
     /// Custom case compare that probably will not work with
     /// locals and so on.
@@ -784,6 +785,7 @@ namespace TinyJSON
       }
       return tolower(*s1) - tolower(*s2);
     }
+#endif
 
     /// <summary>
     /// Do a binary search and return either the exact location of the item
@@ -810,7 +812,13 @@ namespace TinyJSON
       {
         // the middle is the floor.
         middle = static_cast<unsigned int>(first + (last - first) / 2);
+#if TJ_KEY_CASE_SENSITIVE == 1
+        // we do not want duplicate keys
         auto compare = case_compare(_values_dictionary[middle]._key, key);
+#else
+        // we are not case sensitive
+        auto compare = strcmp(_values_dictionary[middle]._key, key);
+#endif
         if (compare == 0)
         {
           search_result result = {};

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -569,16 +569,20 @@ namespace TinyJSON
       // insensitive one where the index is the same.
       // unless both are the same ... but they might not be.
       auto binary_search_result_cs = binary_search(key, true);
-      int index_cs = binary_search_result_cs._was_found ? binary_search_result_cs._dictionary_index : -1;
+      auto dictionary_index_cs = binary_search_result_cs._dictionary_index;
+      int value_index_cs = binary_search_result_cs._was_found ? _values_dictionary_cs[binary_search_result_cs._dictionary_index]._value_index : -1;
+
       auto binary_search_result_ci = binary_search(key, false);
-      auto index_ci = binary_search_result_cs._was_found ? binary_search_result_ci._dictionary_index : -1;
-      if (index_cs == -1)
+      auto dictionary_index_ci = binary_search_result_ci._dictionary_index;
+      int value_index_ci = binary_search_result_ci._was_found ? _values_dictionary_cs[binary_search_result_ci._dictionary_index]._value_index : -1;
+      if (value_index_cs == -1)
       {
-        TJASSERT(index_cs == -1);
+        TJASSERT(value_index_ci == -1); //  how can it be???
+                                        // surely if we do not have one we do not have the other 
         return false;
       }
 
-      if (index_ci == index_cs)
+      if (value_index_cs == value_index_ci)
       {
         /// life is good, we are all pointing at the same code.
         // so we can remove both values
@@ -588,12 +592,12 @@ namespace TinyJSON
         remove_dictionary_data(key, false);
       }
       else
-      if (index_ci != index_cs)
+      if (value_index_cs != value_index_ci)
       {
         //  hum ... we now need to delete the _actual_ value
       }
 
-      shift_value_right(index_cs);
+      shift_value_right(value_index_cs);
       return true;
     }
 

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -10,6 +10,13 @@
 #define TJ_INCLUDE_STD_STRING 0
 #endif
 
+// According to the spec the keys are case sensitive
+// set this value to 1 if you _do not_ want this behaviour
+// so { "a" : 12} is the same as { "A" : 12} 
+#ifndef TJ_KEY_CASE_SENSITIVE
+#define TJ_KEY_CASE_SENSITIVE 0
+#endif
+
 // use the std vector or not, (use the custom array).
 // using the vector can cause performance issue as the
 // array is optimised for deep searches.

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -10,13 +10,6 @@
 #define TJ_INCLUDE_STD_STRING 0
 #endif
 
-// According to the spec the keys are case sensitive
-// set this value to 1 if you _do not_ want this behaviour
-// so { "a" : 12} is the same as { "A" : 12} 
-#ifndef TJ_KEY_CASE_SENSITIVE
-#define TJ_KEY_CASE_SENSITIVE 0
-#endif
-
 // use the std vector or not, (use the custom array).
 // using the vector can cause performance issue as the
 // array is optimised for deep searches.
@@ -339,7 +332,7 @@ class TJDictionary;
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    const TJCHAR* try_get_string(const TJCHAR* key, bool case_sensitive = true) const;
+    const TJCHAR* try_get_string(const TJCHAR* key, bool case_sensitive = true) const;    
 
 #if TJ_INCLUDE_STD_STRING == 1
     /// <summary>
@@ -347,7 +340,7 @@ class TJDictionary;
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    inline const TJCHAR* try_get_string(const std::string& key, bool case_sensitive = true) const
+    inline const TJCHAR* try_get_string(const std::string& key, bool case_sensitive = true) const    
     {
       return try_get_string(key.c_str(), case_sensitive);
     }

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -337,16 +337,28 @@ class TJDictionary;
     /// <summary>
     /// Try and get a string value, if it does not exist, then we return null.
     /// </summary>
-    /// <param name="name"></param>
+    /// <param name="key"></param>
     /// <returns></returns>
-    const TJCHAR* try_get_string(const TJCHAR* name) const;
+    const TJCHAR* try_get_string(const TJCHAR* key, bool case_sensitive = true) const;
+
+#if TJ_INCLUDE_STD_STRING == 1
+    /// <summary>
+    /// Try and get a string value, if it does not exist, then we return null.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    inline const TJCHAR* try_get_string(const std::string& key, bool case_sensitive = true) const
+    {
+      return try_get_string(key.c_str(), case_sensitive);
+    }
+#endif
 
     /// <summary>
     /// Try and get the value of this member if it exists.
     /// </summary>
-    /// <param name="name"></param>
+    /// <param name="key"></param>
     /// <returns></returns>
-    virtual const TJValue* try_get_value(const TJCHAR* name) const;
+    virtual const TJValue* try_get_value(const TJCHAR* key, bool case_sensitive = true) const;
 
 #if TJ_INCLUDE_STD_STRING == 1
     /// <summary>
@@ -354,9 +366,9 @@ class TJDictionary;
     /// </summary>
     /// <param name="name"></param>
     /// <returns></returns>
-    inline const TJValue* try_get_value(const std::string& name) const
+    inline const TJValue* try_get_value(const std::string& key, bool case_sensitive = true) const
     {
-      return try_get_value(name.c_str());
+      return try_get_value(key.c_str(), case_sensitive);
     }
 #endif
 

--- a/tests/testjsonchecker.cpp
+++ b/tests/testjsonchecker.cpp
@@ -207,28 +207,39 @@ TEST(JSONchecker, CaseSensitiveCaseEdgeCases)
   object->set("a1", 1);
   object->set("b2", 2);
   object->set("c3", 3);
-  object->set("A4", 3);
+  object->set("A4", 4);
 
-  auto a = object->try_get_value("a1", false); //  case is correct
+  const TinyJSON::TJValueNumberInt* a = nullptr;
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("a1", false)); //  case is correct
   ASSERT_NE(nullptr, a);
+  ASSERT_EQ(1, a->get_number());
 
   // case sensitive search, (default)
-  auto acs = object->try_get_value("a1", true); //  case is correct
-  ASSERT_NE(nullptr, acs);
-  auto acs2 = object->try_get_value("A1", true); // case is wrong 
-  ASSERT_EQ(nullptr, acs2);
-  auto acs3 = object->try_get_value("A1", false); // case is wrong .... but we don't care
-  ASSERT_NE(nullptr, acs3);
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("a1", true)); //  case is correct
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(1, a->get_number());
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("A1", true)); // case is wrong 
+  ASSERT_EQ(nullptr, a);
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("A1", false)); // case is wrong .... but we don't care
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(1, a->get_number());
 
-  auto b = object->try_get_value("b2", true);
-  ASSERT_NE(nullptr, b);
-  auto c = object->try_get_value("c3", true);
-  ASSERT_NE(nullptr, c);
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("b2", true));
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(2, a->get_number());
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("c3", true));
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(3, a->get_number());
 
-  auto a2 = object->try_get_value("A4", true);  // case is good
-  ASSERT_NE(nullptr, a2);
-  auto a3 = object->try_get_value("A4", false); // case is good ... but we don;t care
-  ASSERT_NE(nullptr, a3);
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("A4", true));  // case is good
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(4, a->get_number());
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("A4", false)); // case is good ... but we don't care
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(4, a->get_number());
+  a = dynamic_cast<const TinyJSON::TJValueNumberInt *>(object->try_get_value("a4", false)); // case is wrong ... but we don't care
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(4, a->get_number());
 
   delete object;
 }

--- a/tests/testjsonchecker.cpp
+++ b/tests/testjsonchecker.cpp
@@ -17,7 +17,7 @@
 #include <chrono>
 
 std::string generateRandomString(size_t length) {
-  const std::string characters = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const std::string characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   std::random_device rd;
   std::mt19937 generator(rd());
   std::uniform_int_distribution<> distribution(0, characters.size() - 1);
@@ -154,6 +154,81 @@ TEST(JSONchecker, LargeShallowObjectCheck)
   auto end2 = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration2 = end2 - start2;
   GTEST_LOG_(INFO) << "Search: " << duration2.count() << " seconds";
+
+  delete object;
+}
+
+bool object_shallow()
+{
+  // create an empty object and add some items to it.
+  auto object = new TinyJSON::TJValueObject();
+
+  // then add a lot of items
+  std::map<std::string, int> data;
+  const int numbers_to_add = 10;
+  for (auto i = 0; i < numbers_to_add; ++i)
+  {
+    auto key = generateRandomString(20);  //  long string to prevent colisions.
+    auto value = generateRandomNumber(0, 5000);
+    object->set(key.c_str(), value);
+    data[key] = value;
+  }
+
+  // then search each and every item
+  for (auto d : data)
+  {
+    auto key = d.first;
+    auto value = d.second;
+    auto tj = object->try_get_value(key.c_str());
+    auto number = dynamic_cast<const TinyJSON::TJValueNumberInt*>(tj);
+    if (number == nullptr)
+    {
+      std::cout << "  Error! Values was not found!\n";
+      return false;
+    }
+    if (number->get_number() != value)
+    {
+      std::cout << "  Error! Values mismatch\n";
+      return false;
+    }
+  }
+  delete object;
+  return true;
+}
+
+TEST(JSONchecker, object_shallow)
+{
+  ASSERT_TRUE(object_shallow());
+}
+
+TEST(JSONchecker, CaseSensitiveCaseEdgeCases)
+{
+  auto object = new TinyJSON::TJValueObject();
+  object->set("a1", 1);
+  object->set("b2", 2);
+  object->set("c3", 3);
+  object->set("A4", 3);
+
+  auto a = object->try_get_value("a1", false); //  case is correct
+  ASSERT_NE(nullptr, a);
+
+  // case sensitive search, (default)
+  auto acs = object->try_get_value("a1", true); //  case is correct
+  ASSERT_NE(nullptr, acs);
+  auto acs2 = object->try_get_value("A1", true); // case is wrong 
+  ASSERT_EQ(nullptr, acs2);
+  auto acs3 = object->try_get_value("A1", false); // case is wrong .... but we don't care
+  ASSERT_NE(nullptr, acs3);
+
+  auto b = object->try_get_value("b2", true);
+  ASSERT_NE(nullptr, b);
+  auto c = object->try_get_value("c3", true);
+  ASSERT_NE(nullptr, c);
+
+  auto a2 = object->try_get_value("A4", true);  // case is good
+  ASSERT_NE(nullptr, a2);
+  auto a3 = object->try_get_value("A4", false); // case is good ... but we don;t care
+  ASSERT_NE(nullptr, a3);
 
   delete object;
 }

--- a/tests/testtinyjson.cpp
+++ b/tests/testtinyjson.cpp
@@ -574,9 +574,9 @@ TEST(TestBasic, UserLiteralsArray)
   ASSERT_NE(nullptr, tjarray);
 
   ASSERT_EQ(3, tjarray->get_number_of_items());
-  ASSERT_TRUE(12, tjarray->at(0)->is_number());
-  ASSERT_TRUE(13, tjarray->at(1)->is_number());
-  ASSERT_TRUE(4, tjarray->at(2)->is_number());
+  ASSERT_TRUE(tjarray->at(0)->is_number());
+  ASSERT_TRUE(tjarray->at(1)->is_number());
+  ASSERT_TRUE(tjarray->at(2)->is_number());
 
   delete json;
 }

--- a/tests/testtinyjson.cpp
+++ b/tests/testtinyjson.cpp
@@ -629,3 +629,27 @@ TEST(TestBasic, DeleteItemWhenWeHaeCaseInsensitiveItemsOppositeOrder)
 
   delete object;
 }
+
+TEST(TestBasic, DeleteAnIemAndMakeSureAllTheValuesAreShiftedProperly)
+{
+  // inser 2 items that are the same
+  auto object = new TinyJSON::TJValueObject();
+  object->set("a1", 1);
+  object->set("A1", 2);
+  object->set("a2", 3);
+  object->set("A2", 4);
+
+  // remove the lower case one
+  // this is the exact opposite of the previous test
+  object->pop("a1");
+
+  auto text = object->dump();
+  ASSERT_STREQ(R"({
+  "A1": 2,
+  "a2": 3,
+  "A2": 4
+})", text);
+
+  delete object;
+}
+

--- a/tests/testtinyjson.cpp
+++ b/tests/testtinyjson.cpp
@@ -592,3 +592,21 @@ TEST(TestBasic, UserLiteralsArrayOutputToIndented)
   14
 ])", json.c_str());
 }
+
+TEST(TestBasic, DeleteItemWhenWeHaeCaseInsensitiveItems)
+{
+  // inser 2 items that are the same
+  auto object = new TinyJSON::TJValueObject();
+  object->set("a1", 1);
+  object->set("A1", 2);
+
+  // remove the upper case one
+  object->pop("A1");
+
+  auto text = object->dump();
+  ASSERT_STREQ(R"({
+  "a1": 1
+})", text);
+
+  delete object;
+}

--- a/tests/testtinyjson.cpp
+++ b/tests/testtinyjson.cpp
@@ -610,3 +610,22 @@ TEST(TestBasic, DeleteItemWhenWeHaeCaseInsensitiveItems)
 
   delete object;
 }
+
+TEST(TestBasic, DeleteItemWhenWeHaeCaseInsensitiveItemsOppositeOrder)
+{
+  // inser 2 items that are the same
+  auto object = new TinyJSON::TJValueObject();
+  object->set("a1", 1);
+  object->set("A1", 2);
+
+  // remove the lower case one
+  // this is the exact opposite of the previous test
+  object->pop("a1");
+
+  auto text = object->dump();
+  ASSERT_STREQ(R"({
+  "A1": 2
+})", text);
+
+  delete object;
+}

--- a/tests/testtinyjsonobjects.cpp
+++ b/tests/testtinyjsonobjects.cpp
@@ -468,3 +468,35 @@ TEST(TestObjects, PopTheLastItem)
 })");
   delete object;
 }
+
+TEST(TestObjects, CaseInSensitiveSearch) {
+  auto json = TinyJSON::TJ::parse(R"(
+    {
+      "Hello" : 12,
+      "WORld" : 14
+    }
+    )"
+  );
+
+  ASSERT_NE(nullptr, json);
+  ASSERT_NE(nullptr, dynamic_cast<TinyJSON::TJValue*>(json));
+
+  const auto jobject = dynamic_cast<TinyJSON::TJValueObject*>(json);
+  ASSERT_NE(nullptr, jobject);
+  ASSERT_EQ(2, jobject->get_number_of_items());
+
+  const auto a = dynamic_cast<const TinyJSON::TJValueNumberInt*>(jobject->try_get_value("hello", false));
+  ASSERT_NE(nullptr, a);
+  ASSERT_EQ(12, a->get_number());
+
+  const auto a1 = dynamic_cast<const TinyJSON::TJValueNumberInt*>(jobject->try_get_value("hello", true));
+  ASSERT_EQ(nullptr, a1);
+
+  const auto b = dynamic_cast<const TinyJSON::TJValueNumberInt*>(jobject->try_get_value("world", false));
+  ASSERT_NE(nullptr, b);
+  ASSERT_EQ(14, b->get_number());
+
+  const auto b1 = dynamic_cast<const TinyJSON::TJValueNumberInt*>(jobject->try_get_value("world", true));
+  ASSERT_EQ(nullptr, b1);
+  delete json;
+}

--- a/tests/testtinyjsonstrings.cpp
+++ b/tests/testtinyjsonstrings.cpp
@@ -623,3 +623,40 @@ TEST(TestStrings, ValidHexValues) {
 
   delete json;
 }
+
+#if TJ_KEY_CASE_SENSITIVE == 0
+TEST(TestStrings, KeysAreNotCaseSensitive) {
+#else
+TEST(TestStrings, KeysAreCaseSensitive) {
+#endif
+  auto tjjson = TinyJSON::TJ::parse(R"(
+{
+  "e" : 12,
+  "e" : 14,
+  "E" : 15,
+  "Hello" : "a",
+  "HELLO" : "b"
+}
+)"
+);
+
+  ASSERT_NE(nullptr, tjjson);
+
+  auto json = tjjson->dump();
+
+#if TJ_KEY_CASE_SENSITIVE == 0
+  ASSERT_STREQ(json, R"({
+  "e": 14,
+  "E": 15,
+  "Hello": "a",
+  "HELLO": "b"
+})");
+#else
+  ASSERT_STREQ(json, R"({
+  "E": 15,
+  "HELLO": "b"
+})");
+#endif
+  
+  delete tjjson;
+}

--- a/tests/testtinyjsonstrings.cpp
+++ b/tests/testtinyjsonstrings.cpp
@@ -624,11 +624,8 @@ TEST(TestStrings, ValidHexValues) {
   delete json;
 }
 
-#if TJ_KEY_CASE_SENSITIVE == 0
-TEST(TestStrings, KeysAreNotCaseSensitive) {
-#else
-TEST(TestStrings, KeysAreCaseSensitive) {
-#endif
+TEST(TestStrings, KeysAreNotCaseSensitive) 
+{
   auto tjjson = TinyJSON::TJ::parse(R"(
 {
   "e" : 12,
@@ -644,19 +641,12 @@ TEST(TestStrings, KeysAreCaseSensitive) {
 
   auto json = tjjson->dump();
 
-#if TJ_KEY_CASE_SENSITIVE == 0
   ASSERT_STREQ(json, R"({
   "e": 14,
   "E": 15,
   "Hello": "a",
   "HELLO": "b"
 })");
-#else
-  ASSERT_STREQ(json, R"({
-  "E": 15,
-  "HELLO": "b"
-})");
-#endif
   
   delete tjjson;
 }


### PR DESCRIPTION
This fixes issue #24 

We are now case sensitive, as per the specs, (see the original bug report).

I did not implement a MACRO to allow the user to pick and choose what they prefer, it does not make sense to me to have it that way.

 The documents have been updated as well.