### PR TITLE
Fix - Dumping large json object, (minify or not), is slow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -90,3 +90,27 @@ jobs:
       run: |
         set +e
         ./basic_parse
+
+  fast_dump:
+    name: Fast dump test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: build fast dump c++11
+      run: g++ -std=c++11 -Wall -Wextra -Werror -O3 src/TinyJSON.cpp example/fast_dump.cpp -o fast_dump
+
+    - name: run fast dump c++11
+      run: |
+        set +e
+        ./fast_dump        
+
+    - name: build fast dump c++20
+      run: g++ -std=c++20 -Wall -Wextra -Werror -O3 src/TinyJSON.cpp example/fast_dump.cpp -o fast_dump
+
+    - name: run fast dump c++20
+      run: |
+        set +e
+        ./fast_dump        
+  

--- a/example/README.md
+++ b/example/README.md
@@ -44,3 +44,7 @@ User Literals are like shortcuts to the code, the user_literals code shows how t
 
   std::cout << "[12,13,14]"_tj_indent;
 ```
+
+## Fast dump
+
+This example shows us how to create and dump large data, this is mainly to test that there is not data loss.

--- a/example/basic_parse.cpp
+++ b/example/basic_parse.cpp
@@ -87,7 +87,12 @@ bool object_shallow()
   std::chrono::duration<double> duration2 = end2 - start2;
   std::cout << "Search: " << duration2.count() << " seconds\n";
 
+  auto start3 = std::chrono::high_resolution_clock::now();
   std::cout << "JSON Size: " << calculateSizeInMegabytes(object->dump()) << " mb\n";
+
+  auto end3 = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> duration3 = end3 - start3;
+  std::cout << "Dump: " << duration3.count() << " seconds\n";
 
   delete object;
   return true;

--- a/example/fast_dump.cpp
+++ b/example/fast_dump.cpp
@@ -1,0 +1,95 @@
+// Licensed to Florent Guelfucci under one or more agreements.
+// Florent Guelfucci licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+#include <iostream>
+#include <string>
+#include <random>
+#include <map>
+#include <regex>
+#include <chrono>
+#include <cstring>
+
+#include "../src/TinyJSON.h"
+
+double calculateSizeInMegabytes(const char* str) {
+  // Get the length of the string in bytes
+  size_t lengthInBytes = std::strlen(str);
+
+  // Convert bytes to megabytes
+  double lengthInMegabytes = static_cast<double>(lengthInBytes) / (1024 * 1024);
+
+  return lengthInMegabytes;
+}
+
+std::string generateRandomString(size_t length) {
+  const std::string characters = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  std::random_device rd;
+  std::mt19937 generator(rd());
+  std::uniform_int_distribution<> distribution(0, characters.size() - 1);
+
+  std::string randomString;
+  for (size_t i = 0; i < length; ++i) {
+    randomString += characters[distribution(generator)];
+  }
+  return randomString;
+}
+
+int generateRandomNumber(int min, int max) {
+  std::random_device rd; // Seed for the random number generator
+  std::mt19937 generator(rd()); // Mersenne Twister random number generator
+  std::uniform_int_distribution<> distribution(min, max); // Uniform distribution within [min, max]
+
+  return distribution(generator);
+}
+
+bool object_dump(const int numbers_to_add)
+{
+  // Get the start time
+  auto start1 = std::chrono::high_resolution_clock::now();
+
+  // create an empty object and add some items to it.
+  auto object = new TinyJSON::TJValueObject();
+
+  // then add a lot of items
+  std::map<std::string, int> data;
+  for (auto i = 0; i < numbers_to_add; ++i)
+  {
+    auto key = generateRandomString(20);  //  long string to prevent colisions.
+    auto value = generateRandomNumber(0, 5000);
+    object->set(key.c_str(), value);
+    data[key] = value;
+  }
+
+  std::cout << "Added: " << data.size() << " items." << "\n";
+
+  auto end1 = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> duration1 = end1 - start1;
+  std::cout << "Insert: " << duration1.count() << " seconds" << "\n";
+
+  auto start2 = std::chrono::high_resolution_clock::now();
+  std::cout << "JSON Size: " << calculateSizeInMegabytes(object->dump()) << " mb\n";
+
+  auto end2 = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> duration2 = end2 - start2;
+  std::cout << "Dump: " << duration2.count() << " seconds\n";
+
+  delete object;
+  return true;
+}
+
+int main()
+{
+  if (!object_dump(1000))
+  {
+    return -1;
+  }
+  if (!object_dump(10000))
+  {
+    return -1;
+  }
+  if (!object_dump(100000))
+  {
+    return -1;
+  }
+  return 0;
+}

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -13,6 +13,8 @@
 
 static constexpr short TJ_MAX_NUMBER_OF_DIGGITS = 19;
 static constexpr short TJ_DEFAULT_STRING_READ_SIZE = 10;
+static constexpr unsigned int TJ_DEFAULT_STRING_MAX_READ_SIZE = 4294967295;
+static constexpr unsigned int TJ_DEFAULT_STRING_MAX_READ_GROW = TJ_DEFAULT_STRING_MAX_READ_SIZE / 2;
 
 static constexpr TJCHAR TJ_NULL_TERMINATOR = '\0';
 
@@ -1796,10 +1798,26 @@ namespace TinyJSON
         return TJ_DEFAULT_STRING_READ_SIZE;
       }
 
-      //  multiply our capacity by 2
-      unsigned int resize_length = current_length << 1;
-      TJCHAR* new_string = new TJCHAR[resize_length];
+      if (current_length >= TJ_DEFAULT_STRING_MAX_READ_SIZE)
+      {
+        // we have reached the limit
+        // we simply cannot go further and we do not want to risk further corruption.
+        _Exit(-1);
+      }
+      unsigned int resize_length = 0;
+      if (current_length >= TJ_DEFAULT_STRING_MAX_READ_GROW)
+      {
+        // we are about to reach the limit, if we cannot make it here, we will break.
+        resize_length = TJ_DEFAULT_STRING_MAX_READ_SIZE;
+      }
+      else
+      {
+        //  multiply our capacity by 2
+        resize_length = current_length << 1;
+      }
 
+      // create the new array.
+      TJCHAR* new_string = new TJCHAR[resize_length];
       memmove(new_string, source, current_length* sizeof(TJCHAR));
       memset(new_string+ current_length, TJ_NULL_TERMINATOR, sizeof(TJCHAR) * (resize_length- current_length));
       delete[] source;

--- a/src/TinyJSON.cpp
+++ b/src/TinyJSON.cpp
@@ -1786,16 +1786,18 @@ namespace TinyJSON
     /// <param name="source"></param>
     /// <param name="length"></param>
     /// <param name="resize_length"></param>
+    /// <param name="needed_length">How much we should grow at least by</param>
     /// <returns></returns>
-    static unsigned int resize_string(TJCHAR*& source, unsigned int current_length)
+    static unsigned int resize_string(TJCHAR*& source, unsigned int current_length, const unsigned int needed_length)
     {
       //  create the new string
       if (source == nullptr)
       {
-        TJCHAR* new_string = new TJCHAR[TJ_DEFAULT_STRING_READ_SIZE];
-        memset(new_string, TJ_NULL_TERMINATOR, sizeof(TJCHAR) * TJ_DEFAULT_STRING_READ_SIZE);
+        auto grow_by = needed_length > TJ_DEFAULT_STRING_READ_SIZE ? needed_length : TJ_DEFAULT_STRING_READ_SIZE;
+        TJCHAR* new_string = new TJCHAR[grow_by];
+        memset(new_string, TJ_NULL_TERMINATOR, sizeof(TJCHAR) * grow_by);
         source = new_string;
-        return TJ_DEFAULT_STRING_READ_SIZE;
+        return grow_by;
       }
 
       if (current_length >= TJ_DEFAULT_STRING_MAX_READ_SIZE)
@@ -1812,8 +1814,24 @@ namespace TinyJSON
       }
       else
       {
-        //  multiply our capacity by 2
-        resize_length = current_length << 1;
+        // we are about to multiply by 2
+        // so if the length is less what we need this will be an issue.
+        if (current_length < needed_length)
+        {
+          if (needed_length > TJ_DEFAULT_STRING_MAX_READ_GROW)
+          {
+            resize_length += TJ_DEFAULT_STRING_MAX_READ_GROW;
+          }
+          else
+          {
+            resize_length += needed_length;
+          }
+        }
+        else
+        {
+          //  multiply our capacity by 2
+          resize_length = current_length << 1;
+        }
       }
 
       // create the new array.
@@ -1825,32 +1843,48 @@ namespace TinyJSON
       return resize_length;
     }
 
+    /// <summary>
+    /// As the name implies, we will add a single character to an existing string.
+    /// </summary>
+    /// <param name="char_to_add"></param>
+    /// <param name="buffer"></param>
+    /// <param name="buffer_pos"></param>
+    /// <param name="buffer_max_length"></param>
     static void add_char_to_string(const TJCHAR char_to_add, TJCHAR*& buffer, int& buffer_pos, int& buffer_max_length) noexcept
     {
       if (buffer_pos + 1 >= buffer_max_length)
       {
-        buffer_max_length = resize_string(buffer, buffer_max_length);
+        buffer_max_length = resize_string(buffer, buffer_max_length, 1);
       }
       buffer[buffer_pos] = char_to_add;
       buffer[buffer_pos+1] = TJ_NULL_TERMINATOR;
       ++buffer_pos;
     }
 
+    /// <summary>
+    /// Add a string to the buffer string.
+    /// </summary>
+    /// <param name="string_to_add"></param>
+    /// <param name="buffer"></param>
+    /// <param name="buffer_pos"></param>
+    /// <param name="buffer_max_length"></param>
     static void add_string_to_string(const TJCHAR* string_to_add, TJCHAR*& buffer, int& buffer_pos, int& buffer_max_length) noexcept
     {
       if (nullptr == string_to_add)
       {
         return;
       }
-      if (nullptr == buffer)
+
+      // what we want to add
+      auto length = strlen(string_to_add);
+      int total_length = length + sizeof(TJCHAR);//  we need one extra for the null char
+      if (buffer_pos + total_length >= buffer_max_length)
       {
-        buffer_max_length = resize_string(buffer, buffer_max_length);
+        buffer_max_length = resize_string(buffer, buffer_max_length, buffer_pos+total_length);
       }
-      while (*string_to_add != TJ_NULL_TERMINATOR)
-      {
-        add_char_to_string(*string_to_add, buffer, buffer_pos, buffer_max_length);
-        string_to_add++;
-      }
+      memcpy(buffer + buffer_pos, string_to_add, length);
+      buffer[buffer_pos+length] = TJ_NULL_TERMINATOR;
+      buffer_pos += length;
     }
 
     static bool try_add_char_to_string_after_escape(const TJCHAR*& source, TJCHAR*& result, int& result_pos, int& result_max_length)

--- a/tests/testjsonchecker.cpp
+++ b/tests/testjsonchecker.cpp
@@ -243,3 +243,53 @@ TEST(JSONchecker, CaseSensitiveCaseEdgeCases)
 
   delete object;
 }
+
+double calculateSizeInMegabytes(const char* str) {
+  // Get the length of the string in bytes
+  size_t lengthInBytes = std::strlen(str);
+
+  // Convert bytes to megabytes
+  double lengthInMegabytes = static_cast<double>(lengthInBytes) / (1024 * 1024);
+
+  return lengthInMegabytes;
+}
+
+bool object_dump(const int numbers_to_add)
+{
+  // Get the start time
+  auto start1 = std::chrono::high_resolution_clock::now();
+
+  // create an empty object and add some items to it.
+  auto object = new TinyJSON::TJValueObject();
+
+  // then add a lot of items
+  std::map<std::string, int> data;
+  for (auto i = 0; i < numbers_to_add; ++i)
+  {
+    auto key = generateRandomString(20);  //  long string to prevent colisions.
+    auto value = generateRandomNumber(0, 5000);
+    object->set(key.c_str(), value);
+    data[key] = value;
+  }
+
+  std::cout << "Added: " << data.size() << " items." << "\n";
+
+  auto end1 = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> duration1 = end1 - start1;
+  std::cout << "Insert: " << duration1.count() << " seconds" << "\n";
+
+  auto start2 = std::chrono::high_resolution_clock::now();
+  std::cout << "JSON Size: " << calculateSizeInMegabytes(object->dump()) << " mb\n";
+
+  auto end2 = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> duration2 = end2 - start2;
+  std::cout << "Dump: " << duration2.count() << " seconds\n";
+
+  delete object;
+  return true;
+}
+
+TEST(JSONchecker, object_dump)
+{
+  ASSERT_TRUE(object_dump(1000));
+}


### PR DESCRIPTION
This fixes issue #26 where `dump()` was taking a very large amount of time.

Also added more tests.