### PR TITLE
feat: add operator[] access support for TJValue

### DIFF
--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -713,6 +713,12 @@ class TJDictionary;
     }
 
     TJValueAccessor operator[](const TJCHAR* key) const;
+
+    /// <summary>
+    /// Index access for arrays and objects.
+    /// For objects, the index follows the non-comment item order (same as TJValueObject::at).
+    /// Out-of-range access returns an empty accessor; calling as<T>() yields default values.
+    /// </summary>
     TJValueAccessor operator[](int index) const;
 
 #if TJ_INCLUDE_STD_STRING == 1
@@ -1641,6 +1647,30 @@ class TJDictionary;
     {
     }
 
+#if TJ_INCLUDE_STD_STRING == 1
+    TJValueAccessor(const TJValue* owner, const std::string& key, bool case_sensitive = true) :
+      _owner(owner),
+      _key(nullptr),
+      _index(0),
+      _by_index(false),
+      _case_sensitive(case_sensitive),
+      _key_storage(key)
+    {
+      _key = _key_storage.c_str();
+    }
+
+    TJValueAccessor(const TJValue* owner, std::string&& key, bool case_sensitive = true) :
+      _owner(owner),
+      _key(nullptr),
+      _index(0),
+      _by_index(false),
+      _case_sensitive(case_sensitive),
+      _key_storage(std::move(key))
+    {
+      _key = _key_storage.c_str();
+    }
+#endif
+
     TJValueAccessor(const TJValue* owner, int index) :
       _owner(owner),
       _key(nullptr),
@@ -1673,22 +1703,35 @@ class TJDictionary;
 
     TJValueAccessor operator[](const TJCHAR* key) const
     {
+      // Chained access uses non-throwing lookup for intermediate nodes.
+      // Missing intermediates yield empty accessors (as<T>() returns defaults).
       return TJValueAccessor(get_value_ptr(), key, true);
     }
 
     TJValueAccessor operator[](int index) const
     {
+      // For objects, index follows non-comment item order (same as TJValueObject::at).
+      // Out-of-range yields empty accessor (as<T>() returns defaults).
       return TJValueAccessor(get_value_ptr(), index);
     }
 
 #if TJ_INCLUDE_STD_STRING == 1
     TJValueAccessor operator[](const std::string& key) const
     {
-      return TJValueAccessor(get_value_ptr(), key.c_str(), true);
+      return TJValueAccessor(get_value_ptr(), key, true);
     }
 #endif
 
   private:
+    const TJValue* _owner;
+    const TJCHAR* _key;
+    int _index;
+    bool _by_index;
+    bool _case_sensitive;
+#if TJ_INCLUDE_STD_STRING == 1
+    std::string _key_storage;
+#endif
+
     template<typename T>
     typename std::enable_if<!std::is_same<T, const TJCHAR*>::value, T>::type
     default_value() const
@@ -1735,11 +1778,6 @@ class TJDictionary;
       return object->try_get_value(_key, _case_sensitive);
     }
 
-    const TJValue* _owner;
-    const TJCHAR* _key;
-    int _index;
-    bool _by_index;
-    bool _case_sensitive;
   };
 
   inline TJValueAccessor TJValue::operator[](const TJCHAR* key) const
@@ -1755,7 +1793,7 @@ class TJDictionary;
 #if TJ_INCLUDE_STD_STRING == 1
   inline TJValueAccessor TJValue::operator[](const std::string& key) const
   {
-    return TJValueAccessor(this, key.c_str());
+    return TJValueAccessor(this, key);
   }
 #endif
 

--- a/src/TinyJSON.h
+++ b/src/TinyJSON.h
@@ -445,6 +445,7 @@ class TJDictionary;
   class TJHelper;
   class TJValueArray;
   class TJValueObject;
+  class TJValueAccessor;
 
   // A simple JSON value, the base of all items in a json
   class TJValue
@@ -671,6 +672,12 @@ class TJDictionary;
       return get_vector_internal<V>(std::is_integral<V>());
     }
 
+    template<typename T>
+    T as() const
+    {
+      return get<T>();
+    }
+
   private:
     template<typename V>
     std::vector<V> get_vector_internal(std::true_type) const
@@ -704,6 +711,13 @@ class TJDictionary;
     {
       return const_iterator::make_end(*this);
     }
+
+    TJValueAccessor operator[](const TJCHAR* key) const;
+    TJValueAccessor operator[](int index) const;
+
+#if TJ_INCLUDE_STD_STRING == 1
+    TJValueAccessor operator[](const std::string& key) const;
+#endif
 
   protected:
     parse_options _parse_options;
@@ -1614,6 +1628,136 @@ class TJDictionary;
 
     void free_values();
   };
+
+  class TJValueAccessor
+  {
+  public:
+    TJValueAccessor(const TJValue* owner, const TJCHAR* key, bool case_sensitive = true) :
+      _owner(owner),
+      _key(key),
+      _index(0),
+      _by_index(false),
+      _case_sensitive(case_sensitive)
+    {
+    }
+
+    TJValueAccessor(const TJValue* owner, int index) :
+      _owner(owner),
+      _key(nullptr),
+      _index(index),
+      _by_index(true),
+      _case_sensitive(true)
+    {
+    }
+
+    template<typename T>
+    T as() const
+    {
+      if (_by_index)
+      {
+        auto value = get_value_ptr();
+        if (value == nullptr)
+        {
+          return default_value<T>();
+        }
+        return value->get<T>();
+      }
+
+      const auto* object = dynamic_cast<const TJValueObject*>(_owner);
+      if (object == nullptr)
+      {
+        return default_value<T>();
+      }
+      return object->get<T>(_key, _case_sensitive);
+    }
+
+    TJValueAccessor operator[](const TJCHAR* key) const
+    {
+      return TJValueAccessor(get_value_ptr(), key, true);
+    }
+
+    TJValueAccessor operator[](int index) const
+    {
+      return TJValueAccessor(get_value_ptr(), index);
+    }
+
+#if TJ_INCLUDE_STD_STRING == 1
+    TJValueAccessor operator[](const std::string& key) const
+    {
+      return TJValueAccessor(get_value_ptr(), key.c_str(), true);
+    }
+#endif
+
+  private:
+    template<typename T>
+    typename std::enable_if<!std::is_same<T, const TJCHAR*>::value, T>::type
+    default_value() const
+    {
+      return T();
+    }
+
+    template<typename T>
+    typename std::enable_if<std::is_same<T, const TJCHAR*>::value, const TJCHAR*>::type
+    default_value() const
+    {
+      return TJCHARPREFIX("");
+    }
+
+    const TJValue* get_value_ptr() const
+    {
+      if (_owner == nullptr)
+      {
+        return nullptr;
+      }
+
+      if (_by_index)
+      {
+        const auto* array = dynamic_cast<const TJValueArray*>(_owner);
+        if (array != nullptr)
+        {
+          return array->at(_index);
+        }
+
+        const auto* object = dynamic_cast<const TJValueObject*>(_owner);
+        if (object != nullptr)
+        {
+          auto member = object->at(_index);
+          return member != nullptr ? member->value() : nullptr;
+        }
+        return nullptr;
+      }
+
+      const auto* object = dynamic_cast<const TJValueObject*>(_owner);
+      if (object == nullptr)
+      {
+        return nullptr;
+      }
+      return object->try_get_value(_key, _case_sensitive);
+    }
+
+    const TJValue* _owner;
+    const TJCHAR* _key;
+    int _index;
+    bool _by_index;
+    bool _case_sensitive;
+  };
+
+  inline TJValueAccessor TJValue::operator[](const TJCHAR* key) const
+  {
+    return TJValueAccessor(this, key);
+  }
+
+  inline TJValueAccessor TJValue::operator[](int index) const
+  {
+    return TJValueAccessor(this, index);
+  }
+
+#if TJ_INCLUDE_STD_STRING == 1
+  inline TJValueAccessor TJValue::operator[](const std::string& key) const
+  {
+    return TJValueAccessor(this, key.c_str());
+  }
+#endif
 
   // A string JSon
   class TJValueString : public TJValue

--- a/tests/testtinyjsonvaluesget.cpp
+++ b/tests/testtinyjsonvaluesget.cpp
@@ -346,3 +346,62 @@ TEST(TestValueGet, GetStrictStringFromArrayWillThrow)
 
   delete json;
 }
+
+TEST(TestOperatorAccess, AccessByKeyAndIndex)
+{
+  TinyJSON::parse_options options = {};
+  options.throw_exception = true;
+  options.strict = false;
+  auto json = TinyJSON::TJ::parse(R"(
+    {
+      "a": 1,
+      "b": "text",
+      "c": [10, 20, 30],
+      "d": { "e": 5 }
+    }
+    )", options
+  );
+
+  ASSERT_NE(nullptr, json);
+
+  ASSERT_EQ(1, (*json)["a"].as<int>());
+  ASSERT_EQ(std::string("text"), (*json)["b"].as<std::string>());
+  ASSERT_EQ(20, (*json)["c"][1].as<int>());
+  ASSERT_EQ(5, (*json)["d"]["e"].as<int>());
+
+  ASSERT_EQ(1, (*json)[0].as<int>());
+
+  delete json;
+}
+
+TEST(TestOperatorAccess, AccessArrayRoot)
+{
+  TinyJSON::parse_options options = {};
+  options.throw_exception = true;
+  options.strict = false;
+  auto json = TinyJSON::TJ::parse(R"(
+    [1, 2, 3]
+    )", options
+  );
+
+  ASSERT_NE(nullptr, json);
+  ASSERT_EQ(2, (*json)[1].as<int>());
+
+  delete json;
+}
+
+TEST(TestOperatorAccess, StrictMissingKeyThrows)
+{
+  TinyJSON::parse_options options = {};
+  options.throw_exception = true;
+  options.strict = true;
+  auto json = TinyJSON::TJ::parse(R"(
+    { "a": 1 }
+    )", options
+  );
+
+  ASSERT_NE(nullptr, json);
+  ASSERT_ANY_THROW((*json)["missing"].as<int>());
+
+  delete json;
+}

--- a/tests/testtinyjsonvaluesget.cpp
+++ b/tests/testtinyjsonvaluesget.cpp
@@ -405,3 +405,75 @@ TEST(TestOperatorAccess, StrictMissingKeyThrows)
 
   delete json;
 }
+
+TEST(TestOperatorAccess, StdStringKeyOwnership)
+{
+  TinyJSON::parse_options options = {};
+  options.throw_exception = true;
+  options.strict = false;
+  auto json = TinyJSON::TJ::parse(R"(
+    {
+      "a": 1,
+      "b": 2
+    }
+    )", options
+  );
+
+  ASSERT_NE(nullptr, json);
+
+  std::string key = "a";
+  key.reserve(8);
+  auto accessor = (*json)[key];
+  key[0] = 'b';
+
+  ASSERT_EQ(1, accessor.as<int>());
+
+  auto temp_accessor = (*json)[std::string("a")];
+  ASSERT_EQ(1, temp_accessor.as<int>());
+
+  delete json;
+}
+
+TEST(TestOperatorAccess, ChainedAccessDefaultsOnMissingIntermediate)
+{
+  TinyJSON::parse_options options = {};
+  options.throw_exception = true;
+  options.strict = false;
+  auto json = TinyJSON::TJ::parse(R"(
+    {
+      "a": { "b": 1 }
+    }
+    )", options
+  );
+
+  ASSERT_NE(nullptr, json);
+
+  ASSERT_EQ(1, (*json)["a"]["b"].as<int>());
+  ASSERT_EQ(0, (*json)["missing"]["b"].as<int>());
+
+  delete json;
+}
+
+TEST(TestOperatorAccess, ObjectIndexOrderingAndBounds)
+{
+  TinyJSON::parse_options options = {};
+  options.throw_exception = true;
+  options.strict = false;
+  auto json = TinyJSON::TJ::parse(R"(
+    {
+      "first": 1,
+      "second": 2,
+      "third": 3
+    }
+    )", options
+  );
+
+  ASSERT_NE(nullptr, json);
+
+  ASSERT_EQ(1, (*json)[0].as<int>());
+  ASSERT_EQ(2, (*json)[1].as<int>());
+  ASSERT_EQ(3, (*json)[2].as<int>());
+  ASSERT_EQ(0, (*json)[3].as<int>());
+
+  delete json;
+}


### PR DESCRIPTION
# Description

Adds support for ergonomic `json[key].as<T>()` access syntax and uniform indexed access on `TJValue`.

This introduces:
- `TJValue::as<T>()` as an alias for `get<T>()`
- `TJValue::operator[](const TJCHAR* key)`
- `TJValue::operator[](int index)`
- lightweight accessor chaining support

Supported usage examples:

```cpp
json["name"].as<std::string>();
json["user"]["age"].as<int>();
json[0].as<int>();
```

This implementation keeps the change minimal and localized to existing access behavior.

Fixes #44

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added focused tests for:
- key access with `as<T>()`
- array index access
- object index access
- missing-key exception behavior

All tests pass locally:

```text
539 tests passed
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes